### PR TITLE
Minor tweaks

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,27 +1,30 @@
-## Contributing teaching material
+# Contributing teaching material
 
-The website is rendered to https://nbis-workshop-epigenomics.readthedocs.io/en/latest/ and build with Sphinx. To add or modify the content:
+The website is rendered to <https://nbis-workshop-epigenomics.readthedocs.io/en/latest/> and build with Sphinx. To add or modify the content:
 
-#### Clone this repository
+## Editing workflow
+
+### Clone this repository
+
 ``` bash
-
 # clone the repo
 git clone https://github.com/NBISweden/workshop-epigenomics-RTDs
 cd workshop-epigenomics-RTDs
 
 # checkout feature branch to work on
 git checkout -b session-example
-
 ```
 
-#### Work on
+### Edit files
+
 Add and edit files at will and note that:
 
-**Supported formats**: .rst, .md
-**Tutorial files**: go under `docs/content/tutorials`
-**Links to tutorials**: add to  `docs/content/tutorials/*.rst`
+* **Supported formats**: `.rst`, `.md`
+* **Tutorial files**: go under `docs/content/tutorials`
+* **Links to tutorials**: add to  `docs/content/tutorials/*.rst`
 
-#### Push feature branch to repo
+### Push feature branch to repo
+
 ```bash
 # code & commit changes while working on the materials
 git add session-feature.md
@@ -31,51 +34,47 @@ git commit -m "commit message"
 git push
 ```
 
-_Note Git commit good practices_
+#### Git commits good practices
 
-**Git commits good practices**
-- Commit messages should contain relevant information regarding the feature(s) you add, what type of analyses they can be used for, *etc.*.
-- The subject line should be written in an imperative, e.g. *Fix typos* and be 50 characters or less
-- More about [good commit messages][git-commits]
+* Commit messages should contain relevant information regarding the feature(s) you add, what type of analyses they can be used for, *etc.*.
+* The subject line should be written in an imperative, e.g. *Fix typos* and be 50 characters or less
+* More about [good commit messages][git-commits]
 
-#### Make a pull request to master branch when ready
-- Go to course repository [https://github.com/NBISweden/workshop-epigenomics-RTDs](https://github.com/NBISweden/workshop-epigenomics-RTDs) and create a pull request.
-- **OK** to merge with the main branch, if you know what you're doing and have technical permission to do so.
+### Make a pull request to master branch when ready
 
-*Readthedocs will automatically build the site upon new commits*
+* Go to course repository [https://github.com/NBISweden/workshop-epigenomics-RTDs](https://github.com/NBISweden/workshop-epigenomics-RTDs) and create a pull request.
+* **OK** to merge with the main branch, if you know what you're doing and have technical permission to do so.
 
+> Readthedocs will automatically build the site upon new commits
 
 ## Viewing changes locally
-You can view changes locally while working on. To do so: 
 
-#### Install Sphinx and readthedocs theme
+You can view changes locally while working on. To do so:
 
-```
+### Install Sphinx and readthedocs theme
+
+```bash
 conda install sphinx
 pip install sphinx-rtd-theme
-
-# to support Markdown
-pip install recommonmark
+pip install recommonmark      # to support Markdown
 ```
 
 Versions currently used:
 
-```
+```tsv
 sphinx                    3.2.1
 sphinx-rtd-theme          0.5.0
 ```
 
-
-#### Build the local html
+### Build the local html
 
 In project root (i.e. `/docs`):
 
-```
+```bash
 make html
 ```
 
 The html to view is `_build/html/index.html`
-
 
 ## More of file formats
 
@@ -83,15 +82,14 @@ The html to view is `_build/html/index.html`
 
 It is supported. However, the tables are not rendered properly in html.
 
-
 ### Restructured text `.rst`
+
 The preferred format. A useful primer on syntax:
 
-https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+<https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>
 
+### Issues
 
-##### Issues?
 Contact Agata or Olga
-
 
 [git-commits]: https://chris.beams.io/posts/git-commit/

--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ This is a repository for the NBIS Epigenomics Workshop website.
 
 <!-- Current `rst` version in `master`; older `mkdocs` version in a separate branch -->
 
-### How to contribute?
-See Contributing.md
+## How to contribute
+
+See [Contributing.md](Contributing.md)

--- a/docs/content/online-classroom.rst
+++ b/docs/content/online-classroom.rst
@@ -11,13 +11,13 @@ Course is run with Zoom and Zulip
 
 **Zoom**
 
-* Zoom link [https://stockholmuniversity.zoom.us/j/62068542218](https://stockholmuniversity.zoom.us/j/62068542218)
-* password sent via email
+* Zoom link: https://stockholmuniversity.zoom.us/j/62068542218
+* Password sent via email
 
 **Zulip**
 
-* Zulip [https://workshop-epigenomics.zulipchat.com](https://workshop-epigenomics.zulipchat.com)
-* invitation sent via email
+* Zulip: https://workshop-epigenomics.zulipchat.com
+* Invitation sent via email
 
 We have created
 


### PR DESCRIPTION
* Fixed rendering of Zoom / Zulip URLs on https://nbis-workshop-epigenomics.readthedocs.io/en/latest/content/online-classroom.html
    * Links were written as markdown instead of RST, and linking to the non-existent `https://stockholmuniversity.zoom.us/j/62068542218](https://stockholmuniversity.zoom.us/j/62068542218` (see screenshot below)
* Some OCD markdown edits because I'm so used to working with super strict linting tools 👀 

_Before PR is merged, showing problem:_

---

<img src="https://user-images.githubusercontent.com/465550/100285786-ca7e0b00-2f71-11eb-9c60-155a59ab0a1d.png" width=500>
