### PR TITLE
Minor fixes on Advanced ChIP section

### DIFF
--- a/docs/content/tutorials/quantitativeChip/cut-and-run-data.rst
+++ b/docs/content/tutorials/quantitativeChip/cut-and-run-data.rst
@@ -501,15 +501,24 @@ So another way to look at this is to plot the signal of every dataset in a given
 	:target: Figures/10_heatmaps_subsample.png
 	:alt:
 
-These heatmaps can be generated using ``seqplots``. ``seqplots`` is an ``R`` package that can be installed
-from ``Bioconductor``. It can be run as a shiny app on a browser or from ``Rstudio``. You can check
-how to use it `in this link <https://bioconductor.org/packages/release/bioc/vignettes/seqplots/inst/doc/SeqPlotsGUI.html>`_.
+
+.. warning::
+    These plots were generated in the past using ``seqplots``. Unfortunately, this package `is now deprecated <https://bioconductor.org/packages/release/bioc/html/seqplots.html>`_. You can still
+    use older versions of R and this package, or just generate plots like this using another tool, like :code:`deepTools`. You can see more in their `documentation <https://deeptools.readthedocs.io/en/develop/>`_. And there are also examples in other tutorials, such as the MINUTE-ChIP data tutorial in this section.
+
 
 The subset file this was created on can be copied from the `tmp` folder:
 
 .. code-block:: bash
     
     scp <youruser>@rackham.uppmax.uu.se:/sw/courses/epigenomics/quantitative_chip_simon/K562_CTCF_CnR/tmp/Skene2017_CTCF_CnR_45s_small.bed .
+
+
+Or from your Uppmax node:
+
+.. code-block:: bash
+    
+    cp /sw/courses/epigenomics/quantitative_chip_simon/K562_CTCF_CnR/tmp/Skene2017_CTCF_CnR_45s_small.bed . 
 
 
 **Q: how does the data compare? Note the difference in scale amongst the samples. What other features are different? Which dataset would be better to identify the CTCF binding motif?**

--- a/docs/content/tutorials/quantitativeChip/cut-and-tag-data.rst
+++ b/docs/content/tutorials/quantitativeChip/cut-and-tag-data.rst
@@ -86,13 +86,11 @@ Let’s look more systematically at known H3K27me3 peaks. We are using a publish
 	:target: Figures/14_heatmap.png
 	:alt:
 
-These heatmaps can be generated using ``seqplots``. ``seqplots`` is an ``R`` package that can be installed
-from ``Bioconductor``. It can be run as a shiny app on a browser or from ``Rstudio``. You can check
-how to use it `in this link <https://bioconductor.org/packages/release/bioc/vignettes/seqplots/inst/doc/SeqPlotsGUI.html>`_.
 
-.. note:: 
-    Be sure to mark `custom` as genome when uploading bigWig and BED files to `seqplots`. There may be
-    some incompatibility between hg38 versions in this case.
+.. warning::
+    These plots were generated in the past using ``seqplots``. Unfortunately, this package `is now deprecated <https://bioconductor.org/packages/release/bioc/html/seqplots.html>`_. You can still
+    use older versions of R and this package, or just generate plots like this using another tool, like :code:`deepTools`. You can see more in their `documentation <https://deeptools.readthedocs.io/en/develop/>`_. And there are also examples in other tutorials, such as the MINUTE-ChIP data tutorial in this section.
+
 
 
 **Q: While showing the highest signal to noise (note the scale of the heatmap 0-1000!). Could there be a problem with CUT&Tag?**

--- a/docs/content/tutorials/quantitativeChip/setup-quant-chip.rst
+++ b/docs/content/tutorials/quantitativeChip/setup-quant-chip.rst
@@ -9,10 +9,10 @@ In these tutorials we will be using the following software:
 
 - **deepTools**. Analysis suite for sequencing data. You can read about the installation `in their documentation <https://deeptools.readthedocs.io/en/develop/content/installation.html>`_.
 - **IGV**. `Integrative Genomics Viewer <http://software.broadinstitute.org/software/igv/>`_.
-- **seqplots**. R package for the analysis of bigWig files. It can be run as a shiny app and can be installed from Bioconductor. Check `seqplots Bioconductor web <https://bioconductor.org/packages/release/bioc/html/seqplots.html>`_ for more details.
 - **intervene**. Easy to use R tool that allows to plot overlap between bed files. It can be installed through bioconda and pip (for me it worked using pip, but not conda though). Bedtools is a dependency. See more detailed info `in the intervene documentation site <https://intervene.readthedocs.io/en/latest/install.html>`_.
+- **R**. :code:`ggplot2` and a couple Bioconductor R packages will be needed, mostly as dependencies: :code:`GenomicRanges`, :code:`rtracklayer`. Furthermore, the Spike-in tutorial requires some other packages: :code:`ChIPSeqSpike` and :code:`BSgenome.Hsapiens.UCSC.hg38`.
 
-Additionally, other Bioconductor R packages will be needed, mostly as dependencies: :code:`GenomicRanges`, :code:`rtracklayer`.
+You can run R in any preferred way you have been running during this workshop. The dependencies are small so you probably have these packages installed. Most definitely these are available through Uppmax module system.
 
 Bioconductor packages can be installed in the usual way:
 
@@ -21,7 +21,6 @@ Bioconductor packages can be installed in the usual way:
   if (!requireNamespace("BiocManager", quietly = TRUE))
     install.packages("BiocManager")
   
-  BiocManager::install("seqplots")
   BiocManager::install("GenomicRanges")
   BiocManager::install("rtracklayer")
 
@@ -34,10 +33,12 @@ You can run things from Uppmax as well as on your local laptop. If you choose to
   module load IGV
   module load R_packages
 
-:code:`R_packages` contains all the mentioned R packages and their dependencies: :code:`GenomicRanges`, :code:`rtracklayer`, :code:`seqplots`. Be sure to have the corresponding modules loaded (and :code:`bioinfo-tools` before anything) before running them.
+:code:`R_packages` contains all the mentioned R packages and their dependencies: :code:`GenomicRanges`, :code:`rtracklayer`. Be sure to have the corresponding modules loaded (and :code:`module load bioinfo-tools` before anything) before running them.
 
-However, I recommend to download the bigWig and peak files and look at them locally. Most of the computationally demanding work has been pre-processed and it's probably easier to look at the files on
-IGV locally rather than remote. ``seqplots`` is also easier to run locally.
+
+Things that can be easily done locally across these tutorials: IGV visualization (download the bigWig files as these are not too large), R figures.
+
+Things that will run better on Uppmax: First part of the Minute tutorial is more computationally demanding. It is still small enough that can be run on a laptop, but it will take a few hours. Some deepTools calls, especially fingerprint plots, are also slow, so it may be better to run on Uppmax.
 
 .. note:: 
     Computationally demanding steps have been precalculated and resulting plots are shown. Some of them can optionally be run again (such as ``deepTools`` computations). In those cases it will be noted within the corresponding section. 


### PR DESCRIPTION
Some warnings on seqplots being deprecated, and deepTools as an alternative is mentioned.

Setup section is updated as well.