### PR TITLE
Advanced ChIP tutorials update 2023

### DIFF
--- a/docs/content/tutorials/quantitativeChip/cut-and-run-data.rst
+++ b/docs/content/tutorials/quantitativeChip/cut-and-run-data.rst
@@ -24,22 +24,13 @@ So we will look at a comparison of CUT&RUN and different ChIP datasets to unders
 	:target: Figures/00_CTCF.png
 	:alt:
 
-*Fig. 1: Features of CTCF-binding sites in the genome*
+*Fig. 1*: Features of `CTCF binding sites in the genome <https://doi.org/10.1038/nrg3663>`_ [1]_.
+
 
 Datasets
 ==========
 
-The datasets used correspond to two publications: 
-
-Skene PJ, Henikoff S. An efficient targeted nuclease strategy for high-resolution mapping of DNA binding sites. Elife 2017.
-https://elifesciences.org/articles/21856
-
-Pugacheva, Elena M., et al. CTCF mediates chromatin looping via N-terminal domain-dependent cohesin retention. Proceedings of the National Academy of Sciences 117.4 (2020).
-https://www.pnas.org/content/117/4/2020
-
-They can be found on GEO (GSE84474 and GSE137216). See below a table with the samples included in this example:
-
-In Skene and Henikoff, they compare CUT&Run to their own ChIP (special optimized native ChIP for CTCF they say).
+The datasets used correspond to two publications, Skene and Henikoff [2]_ and Pugacheva et al. [3]_. They can be found on GEO (GSE84474 and GSE137216). See below a table with the samples included in this example:
 
 .. list-table:: Table 1. Files in Skene et al. 2017 used in this exercise.
    :widths: 25 40
@@ -65,7 +56,8 @@ In Skene and Henikoff, they compare CUT&Run to their own ChIP (special optimized
      - NBIS_Skene2017_K562_CTCF_CnR_9m        
 
 
-In Pugacheva et. all, they perform a crosslinking ChIP for CTCF. They’ve been using different antibodies just to be sure that they are ChIPing the right thing.
+
+In Skene and Henikoff, they compare CUT&Run to their own ChIP (special optimized native ChIP for CTCF they say). In Pugacheva et. all, they perform a crosslinking ChIP for CTCF. They’ve been using different antibodies just to be sure that they are ChIPing the right thing.
 
 .. list-table:: Table 2. Files in Pugacheva et al. 2020 used in this exercise.
    :widths: 25 40
@@ -94,7 +86,7 @@ Data preprocessing
 Primary analysis of the initial FASTQ files was performed beforehand. Reads were mapped with ``bowtie2`` with default parameters. Resulting BAM files were deduplicated using Picard and blacklisted regions were removed. Peak files were generated using ``MACS2`` using very standard parameters: ``--qval cutoff 0.01``. In this case no replicates were used to call the peaks. BigWig files were generated with ``deepTools`` to 1x coverage. Resulting files are available under ``/sw/courses/epigenomics/quantitative_chip_simon/K562_CTCF_CnR``
 
 .. attention::
-   You can download bigWig and peak annotations. Most of what we are going to do can be done locally on aregular laptop. When this is not the case, Uppmax-specific instructions will be given. In case something does not work properly, the output of most of these is available also in the workshop folder and in this documentation.
+   You can download bigWig and peak annotations. Most of what we are going to do can be done locally on a regular laptop. When this is not the case, Uppmax-specific instructions will be given. In case something does not work properly, the output of most of these is available also in the workshop folder and in this documentation.
 
 When running things on Uppmax, copy the files to your home directory:
 
@@ -277,7 +269,8 @@ The ``.npz`` matrix is then used by ``deepTools`` to produce other plots. For ou
     plotCorrelation --corData ./bins_table.npz \
         --plotFile ./correlation_spearman_all.png \
         --whatToPlot heatmap \
-        --corMethod spearman
+        --corMethod spearman \
+        --plotNumbers
 
 This will generate a correlation plot based on genome-wide 5kb bins.
 
@@ -354,7 +347,7 @@ The resulting plot should look like:
 
 **Q: What do you think it means in terms of quality of experiments?**
 **Do you see different groups of samples? Go to IGV and browse through the tracks.**
-**How do each of these groups look? Fingerprint supports the difference CUT&RUN authors argue - That it has less background.**
+**How does each group look? Fingerprint supports the difference CUT&RUN authors argue - That it has less background.**
 
 Clearly, the CUT&Run data scores better by QC compared to the CTCF ChIP presented in this paper. But how about comparing to the Pugacheva CTCF ChIP datasets?
 
@@ -383,21 +376,21 @@ Peak calling
 Peaks were called with MACS2 using standard parameters.
 
 .. attention::
-    This is a step that could be better fine tuned to each experimental setting. 
+    This is a step that could be better fine-tuned to specific experimental settings. 
 
-Again, it is usually a good idea to inspect visually the files, so you can have a feeling on whether the peaks were correctly called and how the samples look like.
+Again, it is usually a good idea to visually inspect the tracks, so you can have a feeling on whether the peaks were correctly called and how the samples look like.
 
 
 .. image:: Figures/05_IGV_peaks.png
 	:target: Figures/05_IGV_peaks.png
 	:alt:
 
-**Q: Given the QC you did above, does the peak calling confirm the quality differences amongst the samples? Does a higher signal/noise allows to identify more peaks? Call peaks more confidently?**
+**Q: Given the QC you did above, does the peak calling confirm the quality differences amongst the samples? Does a higher signal/noise ratio allow to identify more peaks? Are peaks more confidently called?**
 
 Number of peaks per sample
 --------------------------
 
-A simple ``wc`` count per peak file allows you to quickly check how many peaks you got:
+A simple ``wc`` count allows you to quickly check how many peaks you got:
 
 .. code-block:: bash
 
@@ -420,21 +413,24 @@ A simple ``wc`` count per peak file allows you to quickly check how many peaks y
 Peaks overlap using intervene
 ------------------------------
 
-``intervene`` is an easy to use tool to look for overlaps between BED files. It relies on ``bedtools``, but saves some work when looking at different sets of files. You can install it using ``pip`` as they `explain <https://intervene.readthedocs.io/en/latest/install.html>`_.
+``intervene`` is an easy-to-use tool to look for overlaps between BED files. It relies on ``bedtools``, but it saves some work when looking at different sets of files. You can install it using ``pip`` as they `explain <https://intervene.readthedocs.io/en/latest/install.html>`_.
 
 .. attention::
-    There is no ``intervene`` module on Uppmax. If you want to run it there, you can probably install it using your usual ``conda`` environment or `pyenv`. See how to set ``pyenv`` `here <https://www.uppmax.uu.se/support/user-guides/python-modules-guide/>`_.
+    There is no ``intervene`` module on Uppmax. If you want to run it there, you can activate a conda environment that is precomputed: ``conda activate /sw/courses/epigenomics/quantitative_chip_simon/condaenv/intervene``. Otherwise you can download the peaks files to your local computer and install intervene there, if you prefer.
 
 You can generate venn diagrams (pairwise or more). For example, we may want to look at how much two of the CTCF ChIP peaks from Pugacheva 2020 agree:
 
 .. code-block::
     
-    # Back to your local laptop copy of the peaks and bw
     cd cnr_chip
+    mkdir peaks
+    cp /sw/courses/epigenomics/quantitative_chip_simon/K562_CTCF_CnR/peaks/*.narrowPeak peaks/
+
+    conda activate /sw/courses/epigenomics/quantitative_chip_simon/condaenv/intervene
 
     intervene venn --in ./peaks/NBIS_Pugacheva2020_K562_ChIP_CTCF_Mono*.narrowPeak
 
-This will output a ``Intervene_results`` folder with a pdf file:
+This will output a ``intervene_results`` folder with a pdf file:
 
 .. image:: Figures/06_venn_1.png
 	:target: Figures/06_venn_1.png
@@ -458,18 +454,18 @@ will generate a plot like this in ``./pairwise_results/``.
 
 Very different numbers of peaks! 
 
-**Q: How do you think the number of peaks relate to the fingerprint? (the ones with the most accentuated fingerprint are the ones showing larger amounts of peaks, however the difference is not such for some of the CnR samples. Why can that be?**
+**Q: How do you think the number of peaks relates to the fingerprint? (the ones with the most accentuated fingerprint are the ones showing larger amounts of peaks, however the difference is not such for some of the CnR samples. Why can that be?**
 
-This has actually been noted in the CnR paper. They say that too scarce background read coverage can throw off traditional peak callers, thus they develop their own peak caller for CnR data.
+This has actually been noted in the CnR paper. They say that too scarce background read coverage can throw off traditional peak callers, thus they develop their own peak caller for CnR data. 
+
 
 **Q: Now that you have peaks, think about what you could do with the peak information. How to make sense of the peaks? Would you use the dataset with the most or the least peaks for downstream analysis?**
 
 .. note::
-    ``MACS`` doesn’t just give peaks, it also assigns a score. High/confident peaks have high score. Small peaks have low score. It is not apparent from the analysis above, but it is quite likely that if you would pick the top 5000 scored peaks from each dataset, the overlap would be extremely good.
+    ``MACS`` doesn’t just give peaks, it also assigns a score. High/confident peaks have high score. Small peaks have low score. It is not apparent from the analysis above, but it is quite likely that if you would pick the top 5000 scored peaks from each dataset, the overlap would be better.
 
 Comparison between methods
 ==========================
-
 
 As an example, we are going to look at one peak set representative for each method: CnR_45s, CTCF_ChIP_medMN from Skene 2017 and ChIP_MonoC from Pugacheva 2020.
 
@@ -480,7 +476,7 @@ We can look at the overlap between them in a venn diagram:
 	:alt:
 
 
-There are quite some differences  between approaches, and one of the peak sets is very small compared to the others.
+There are quite some differences between approaches, and one of the peak sets is very small compared to the others.
 
 .. note::
     These venn diagrams are not size proportional. Automatically drawing size-proportional set intersections is a complex problem. `eulerr` is an `R package <https://cran.r-project.org/web/packages/eulerr/vignettes/introduction.html>`_ that does a really nice job at approximating this. However it’s only for drawing, not for computing the actual intersections.
@@ -489,7 +485,7 @@ There are quite some differences  between approaches, and one of the peak sets i
 Heatmaps
 =========
 
-The fact that there are loci marked as peak in one dataset that do not appear in another does not mean that there is no signal there. It could not be called as peak due to lack of statistical power, the signal being weaker or a combination of other factors. Remember the example in the slides - some peaks don’t make the calling threshold, but still represent sites of enrichment:
+The fact that there are loci marked as peak in one dataset that do not appear in another does not mean that there is no signal there. It could be that a peak is not called due to lack of statistical power, the signal being weaker or a combination of other factors. Remember the example in the slides - some peaks don’t make the threshold, but still show enrichment:
 
 .. image:: Figures/09_peak_example.png
 	:target: Figures/09_peak_example.png
@@ -524,8 +520,16 @@ Or from your Uppmax node:
 **Q: how does the data compare? Note the difference in scale amongst the samples. What other features are different? Which dataset would be better to identify the CTCF binding motif?**
 
 .. note::
-    In the Skene paper, the make a biological interpretation regarding the difference in peaks seen in native ChIP and CUT&Run. They call the peaks uniquely present in CUT&Run “indirect binding sites” because they infer that those peaks are not directly bound by CTCF. The tagging of sites potentially in intact nuclei works through space, thus tagging not only the loci that is bound by CTCF, but also those regions that are nearby in space (Hi-C contacts). So it is important to note that CUT&Run may report ‘indirect’ or ‘shadow’ peaks that do not represent bona fide binding sites. For CTCF in principle the distinction should be easy since the ‘shadow’ peaks should not have CTCF binding motif.
+    In Skene and Henikoff paper, the authors make a biological interpretation regarding the difference in peaks seen in native ChIP and CUT&Run. They call the peaks uniquely present in CUT&Run “indirect binding sites” because they infer that those peaks are not directly bound by CTCF. The tagging of sites potentially in intact nuclei works through space, thus tagging not only the loci that are bound by CTCF, but also those regions that are nearby in space (Hi-C contacts). So it is important to note that CUT&Run may report ‘indirect’ or ‘shadow’ peaks that do not represent bona fide binding sites. For CTCF in principle the distinction should be easy since the ‘shadow’ peaks should **not have CTCF binding motif**.
 
 .. image:: Figures/11_cut_run.png
 	:target: Figures/11_cut_run.png
 	:alt:
+
+
+References
+===============
+
+.. [1] Ong, CT., Corces, V. CTCF: an architectural protein bridging genome topology and function. Nat Rev Genet 15, 234–246 (2014).
+.. [2] Skene PJ, Henikoff S. An efficient targeted nuclease strategy for high-resolution mapping of DNA binding sites. Elife 2017.
+.. [3] Pugacheva, Elena M., et al. CTCF mediates chromatin looping via N-terminal domain-dependent cohesin retention. Proceedings of the National Academy of Sciences 117.4 (2020).

--- a/docs/content/tutorials/quantitativeChip/cut-and-tag-data.rst
+++ b/docs/content/tutorials/quantitativeChip/cut-and-tag-data.rst
@@ -22,24 +22,26 @@ Datasets
 ========
 
 .. list-table:: Table 1. H3K27me3 datasets used in this exercise.
-   :widths: 25 40
+   :widths: 25 40 40
    :header-rows: 1
 
    * - GEO Accession
      - Sample
+     - Reference
    * - GSM3536498
      - hESC_H1_H3K27me3_CnT
+     - Kaya-Okur *et al.* 2019 [1]_
    * - GSM3677833 
-     - NBIS_H1_H3K27me3_CnR    
-   * -   
+     - NBIS_H1_H3K27me3_CnR   
+     - Meers *et al.* 2019 [2]_ 
+   * - 
      - hESC_H1_H3K27me3_ChIP     
+     - 
    * - GSM1436879 
-     - WIBR2_H3K27me3_ChIP       
+     - WIBR2_H3K27me3_ChIP
+     - Theunissen *et al.* 2019 [3]_
 
-H3K27me3-enriched regions from Court et. al. 2017: ``Bivalent_primed.hg38.bed``.
-
-Court, Franck, and Philippe Arnaud. "An annotated list of bivalent chromatin regions in human ES cells: a new tool for cancer epigenetic research." Oncotarget 8.3 (2017): 4110.
-https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5354816/
+H3K27me3-enriched regions from Court *et al.* 2019 [4]_: ``Bivalent_primed.hg38.bed`` (lift-overed from hg19).
 
 
 Data preprocessing
@@ -78,9 +80,9 @@ Smaller H3K27me3 domains.
 	:target: Figures/13_cut_tag_igv.png
 	:alt:
 
-**Q: First impression browsing the H3K27me3 data? Consider the Y axis used for each dataset and what it means for signal/noise.**
+**Q: What are your first impressions browsing the H3K27me3 data? Consider the Y axis used for each dataset and what it means regarding signal/noise ratio.**
 
-Let’s look more systematically at known H3K27me3 peaks. We are using a published bed file of bivalent domains (Court, 2017).
+Let’s look more systematically at known H3K27me3 peaks. We are using a published BED file of bivalent domains (Court *et al.* 2017 [4]_ ).
 
 .. image:: Figures/14_heatmap.png
 	:target: Figures/14_heatmap.png
@@ -93,16 +95,24 @@ Let’s look more systematically at known H3K27me3 peaks. We are using a publish
 
 
 
-**Q: While showing the highest signal to noise (note the scale of the heatmap 0-1000!). Could there be a problem with CUT&Tag?**
+**Q: The heatmaps show a similar colorscale but the signal to noise varies a lot (note the scale of CUT&TAG 0-1000!). Could there be a problem with CUT&Tag?**
 
 A common critique about the in-situ methods is that they may be generating false-positive peaks at accessible sites of the genome, since MNase likes to cut open chromatin and Tn5 also is known to integrate best in open chromatin (ATAC-Seq!).
 
-So we could also plot the signal over active enhancers which are 1) known to have open chromatin and 2) are decorated by H3K27ac, thus cannot have H3K27me3.
+So we could also plot the signal over active enhancers which are 1) known to have open chromatin and 2) are decorated by H3K27ac, thus **cannot have H3K27me3**.
 
 .. image:: Figures/15_heatmap_2.png
 	:target: Figures/15_heatmap_2.png
 	:alt:
 
-**Q: Is the concern of false-positive peaks justified (consider the scale used here and above).**
+**Q: Is the aforementioned concern about false-positive peaks justified (consider the scale used here and above)?**
 
 
+
+References
+===============
+
+.. [1] Kaya-Okur, Hatice S., et al. "CUT&Tag for efficient epigenomic profiling of small samples and single cells." Nature communications 10.1 (2019): 1930.
+.. [2] Meers, Michael P., Derek H. Janssens, and Steven Henikoff. "Pioneer factor-nucleosome binding events during differentiation are motif encoded." Molecular cell 75.3 (2019): 562-575.
+.. [3] Theunissen, Thorold W., et al. "Systematic identification of culture conditions for induction and maintenance of naive human pluripotency." Cell stem cell 15.4 (2014): 471-487.
+.. [4] Court, Franck, and Philippe Arnaud. "An annotated list of bivalent chromatin regions in human ES cells: a new tool for cancer epigenetic research." Oncotarget 8.3 (2017).

--- a/docs/content/tutorials/quantitativeChip/minute-lab.rst
+++ b/docs/content/tutorials/quantitativeChip/minute-lab.rst
@@ -216,49 +216,49 @@ Additionally, we may have some spike-in data from another reference, so Minute a
      - Naive
      - Untreated
      - 1
-     - H3K27m3_H9_naive_rep1_R{1,2}.fastq.gz
+     - H3K27m3-ChIP_H9_naive_rep1_R{1,2}.fastq.gz
    
    * - H3K27m3
      - Naive
      - EZH2i
      - 1
-     - H3K27m3_H9_naive_EZH2i_rep1_R{1,2}.fastq.gz
+     - H3K27m3-ChIP_H9_naive_EZH2i_rep1_R{1,2}.fastq.gz
    
    * - H3K27m3
      - Naive
      - Untreated
      - 1
-     - H3K27m3_H9_primed_rep1_R{1,2}.fastq.gz
+     - H3K27m3-ChIP_H9_primed_rep1_R{1,2}.fastq.gz
    
    * - H3K27m3
      - Primed
      - EZH2i
      - 1
-     - H3K27m3_H9_primed_EZH2i_rep1_R{1,2}.fastq.gz
+     - H3K27m3-ChIP_H9_primed_EZH2i_rep1_R{1,2}.fastq.gz
 
    * - Input
      - Naive
      - Untreated
      - 1
-     - IN_H9_naive_rep1_R{1,2}.fastq.gz
+     - IN-ChIP_H9_naive_rep1_R{1,2}.fastq.gz
   
    * - Input
      - Naive
      - EZH2i
      - 1
-     - IN_H9_naive_EZH2i_rep1_R{1,2}.fastq.gz
+     - IN-ChIP_H9_naive_EZH2i_rep1_R{1,2}.fastq.gz
    
    * - Input
      - Primed
      - Untreated
      - 1
-     - IN_H9_primed_rep1_R{1,2}.fastq.gz
+     - IN-ChIP_H9_primed_rep1_R{1,2}.fastq.gz
    
    * - Input
      - Primed
      - EZH2i
      - 1
-     - IN_H9_primed_EZH2i_rep1_R{1,2}.fastq.gz
+     - IN-ChIP_H9_primed_EZH2i_rep1_R{1,2}.fastq.gz
   
 
 

--- a/docs/content/tutorials/quantitativeChip/minute-lab.rst
+++ b/docs/content/tutorials/quantitativeChip/minute-lab.rst
@@ -53,7 +53,8 @@ Primary analysis
 Conda environment
 ^^^^^^^^^^^^^^^^^
 
-To make sure you have all the necessary tools to run :code:`minute`, you can set up a conda environment using a :code:`environment.yml` specification file:
+To make sure you have all the necessary tools to run :code:`minute`, you can use a conda environment. There is a pre-made version of this environment on: 
+:code:`/sw/courses/epigenomics/quantitative_chip_simon/condaenv/minute` so you can just:
 
 
 .. code-block:: bash
@@ -61,13 +62,23 @@ To make sure you have all the necessary tools to run :code:`minute`, you can set
   module load bioinfo-tools
   module load conda
 
-  conda env create -f /proj/epi2022/minute_chip/minute/environment.yml -n minute_lab 
+  conda activate /sw/courses/epigenomics/quantitative_chip_simon/condaenv/minute
+
+
+If you want to make a fresh install, you can make a new conda environment and install minute in it:
+
+
+.. code-block:: bash
+
+  module load bioinfo-tools
+  module load conda
+
+  conda create -n minute minute
 
 
 .. admonition:: Speed up the process using mamba
 
-   Sometimes :code:`conda` takes long time resolving dependencies on larger environment. An alternative is :code:`mamba`, a reimplementation of :code:`conda` in C++. It is faster
-   on the resolution. However, you might still experience some waiting time!
+   Sometimes :code:`conda` takes long time resolving dependencies on large environments. An alternative is :code:`mamba`, a reimplementation of :code:`conda` in C++. It is faster on the package dependency resolution. However, you might still experience some waiting time!
 
    If you want to use mamba instead (on Uppmax it is included in the `conda module <https://www.uppmax.uu.se/support/user-guides/python-user-guide/>`_), your code would look like:
 
@@ -76,25 +87,7 @@ To make sure you have all the necessary tools to run :code:`minute`, you can set
     module load bioinfo-tools
     module load conda
 
-    mamba env create -f /proj/epi2022/minute_chip/minute/environment.yml -n minute_lab
-
-
-After activating the environment for the first time, you need to install the :code:`minute` package
-in it. You can do this by:
-
-.. code-block:: bash
-
-  cd /proj/epi2022/minute_chip/minute/
-  pip install .
-
-
-If you run into problems configuring this, there is a copy of this conda environment at: :code:`/proj/epi2022/minute_chip/condaenv/minute_lab`
-It should work if you just:
-
-.. code-block:: bash
-
-  export CONDA_ENVS_PATH=/proj/epi2022/minute_chip/condaenv/
-  conda activate /proj/epi2022/minute_chip/condaenv/minute_lab
+    mamba create -n minute minute
 
 
 Files
@@ -152,6 +145,10 @@ Configuration
 
   # Fragment length (insert size)
   fragment_size: 150
+
+  # Max barcode errors allowed
+  max_barcode_errors: 1
+
 
 :code:`libraries.tsv`: Contains information about the demultiplexing. In our case, the barcodes are skipped because we have the already demultiplexed FASTQ files. The raw FASTQ
 mate 1 contains a 6nt UMI followed by a 8nt barcode that identifies the sample.
@@ -286,13 +283,13 @@ If you already got your files, you need to run something like
 
 .. code-block:: bash
 
-  conda activate minute_lab
+  conda activate /sw/courses/epigenomics/quantitative_chip_simon/condaenv/minute
 
   # Move to the directory where you copied the files
   cd my_primary
 
   # Run snakemake on the background, and keep doing something else
-  nohup snakemake -p -s /proj/epi2022/minute_chip/minute/minute/Snakefile -j 6 > minute_pipeline.out 2> minute_pipeline.err &
+  nohup snakemake -p -s /sw/courses/epigenomics/quantitative_chip_simon/minute/src/minute/Snakefile -j 6 > minute_pipeline.out 2> minute_pipeline.err &
 
 
 :code:`-j` is the number of jobs/threads used by :code:`snakemake`. Depending on how many cores there are available on your node, you can raise this value.

--- a/docs/content/tutorials/quantitativeChip/minute-lab.rst
+++ b/docs/content/tutorials/quantitativeChip/minute-lab.rst
@@ -106,10 +106,10 @@ There are 3 replicates for each condition. In the first part of the tutorial you
   cd my_primary/fastq
 
   # Create symlinks to our fastq files
-  for i in /proj/epi2022/minute_chip/primary/*.fastq.gz; do ln -s ${i}; done
+  for i in /sw/courses/epigenomics/quantitative_chip_simon/minute_tutorial/primary/*.fastq.gz; do ln -s ${i}; done
   cd ..
-  cp /proj/epi2022/minute_chip/primary/*.tsv .
-  cp /proj/epi2022/minute_chip/primary/*.yaml .
+  cp /sw/courses/epigenomics/quantitative_chip_simon/minute_tutorial/primary/*.tsv .
+  cp /sw/courses/epigenomics/quantitative_chip_simon/minute_tutorial/primary/*.yaml .
 
 
 Now, this is how your directory structure should look like:
@@ -135,10 +135,10 @@ Configuration
     hg38:  # Arbitrary name for this reference. This is also used in output file names.
       # Path to a reference FASTA file (may be gzip-compressed).
       # A matching Bowtie2 index must exist in the same location.
-      fasta: "/proj/epi2022/minute_chip/reference/hg38.fa"
+      fasta: "/sw/courses/epigenomics/quantitative_chip_simon/minute_tutorial/reference/hg38.fa"
 
       # Path to a BED file with regions to exclude
-      exclude: "/proj/epi2022/minute_chip/reference/hg38.blocklist.bed"
+      exclude: "/sw/courses/epigenomics/quantitative_chip_simon/minute_tutorial/reference/hg38.blocklist.bed"
 
   # Length of the 5' UMI
   umi_length: 6
@@ -210,49 +210,49 @@ Additionally, we may have some spike-in data from another reference, so Minute a
      - Naive
      - Untreated
      - 1
-     - H3K27m3-ChIP_H9_naive_rep1_R{1,2}.fastq.gz
+     - H3K27m3_H9_naive_rep1_R{1,2}.fastq.gz
    
    * - H3K27m3
      - Naive
      - EZH2i
      - 1
-     - H3K27m3-ChIP_H9_naive_EZH2i_rep1_R{1,2}.fastq.gz
+     - H3K27m3_H9_naive_EZH2i_rep1_R{1,2}.fastq.gz
    
    * - H3K27m3
      - Naive
      - Untreated
      - 1
-     - H3K27m3-ChIP_H9_primed_rep1_R{1,2}.fastq.gz
+     - H3K27m3_H9_primed_rep1_R{1,2}.fastq.gz
    
    * - H3K27m3
      - Primed
      - EZH2i
      - 1
-     - H3K27m3-ChIP_H9_primed_EZH2i_rep1_R{1,2}.fastq.gz
+     - H3K27m3_H9_primed_EZH2i_rep1_R{1,2}.fastq.gz
 
    * - Input
      - Naive
      - Untreated
      - 1
-     - IN-ChIP_H9_naive_rep1_R{1,2}.fastq.gz
+     - IN_H9_naive_rep1_R{1,2}.fastq.gz
   
    * - Input
      - Naive
      - EZH2i
      - 1
-     - IN-ChIP_H9_naive_EZH2i_rep1_R{1,2}.fastq.gz
+     - IN_H9_naive_EZH2i_rep1_R{1,2}.fastq.gz
    
    * - Input
      - Primed
      - Untreated
      - 1
-     - IN-ChIP_H9_primed_rep1_R{1,2}.fastq.gz
+     - IN_H9_primed_rep1_R{1,2}.fastq.gz
    
    * - Input
      - Primed
      - EZH2i
      - 1
-     - IN-ChIP_H9_primed_EZH2i_rep1_R{1,2}.fastq.gz
+     - IN_H9_primed_EZH2i_rep1_R{1,2}.fastq.gz
   
 
 
@@ -289,10 +289,10 @@ If you already got your files, you need to run something like
   cd my_primary
 
   # Run snakemake on the background, and keep doing something else
-  nohup snakemake -p -s /sw/courses/epigenomics/quantitative_chip_simon/minute/src/minute/Snakefile -j 6 > minute_pipeline.out 2> minute_pipeline.err &
+  nohup minute run -j 4 > minute_pipeline.out 2> minute_pipeline.err &
 
 
-:code:`-j` is the number of jobs/threads used by :code:`snakemake`. Depending on how many cores there are available on your node, you can raise this value.
+:code:`-j` is the number of jobs/threads used by :code:`snakemake`. Depending on how many cores are available on your node, you can raise this value.
 The amount of files in this part of the tutorial is small enough to be possible to run in a local computer, but it still takes some time. For 4
 out of 8 cores running on my laptop (intel i7), this took around 4 hours to run. If you run this locally, consider not to use all the available
 cores you have, since you still need to run other things on the side and it may eat up your RAM memory as well (more tasks means usually more memory use).
@@ -301,15 +301,27 @@ Since this takes some time to run, my recommendation is that you start running t
 the tutorial in the meantime. It is also recommended, same as before, that you do not use *all* the cores you reserved, so you have some processing
 power for the second part of the tutorial. For instance if you have 12 cores, put 6 here and keep the other 6 for the second part of the tutorial.
 
+Another option is to run the `no_bigwigs` version of the pipeline to get the stats and reports but run it faster, in this case you can replace the
+minute run line above with:
+
+.. code-block:: bash
+
+  nohup minute run no_bigwigs -j 4 > minute_pipeline.out 2> minute_pipeline.err &
+
+
+This will take way less time (bigWig generation is the most time consuming step of this workflow) and you can copy the bigWig files to do the second
+part of the tutorial.
+
+
 .. note::
   You can run something in the background by typing :code:`&` at the end of the command. You can also keep the output to stderr and stdout by using
   :code:`>` and :code:`2>` operators. So the :code:`snakemake` call in the previous block just allows you to do this:
 
   .. code-block:: bash
     
-    nohup snakemake -p /proj/epi2022/minute_chip/minute/minute/Snakefile -j 6 > minute_pipeline.out 2> minute_pipeline.err &
+    nohup minute run -j 4 > minute_pipeline.out 2> minute_pipeline.err &
 
-  `nohup` is a handy command that will make sure that the `snakemake` keeps running even if you logout or are kicked out of the session.
+  `nohup` is a handy command that will make sure that the `snakemake` keeps running even if you logout or are kicked out of the session on Uppmax.
 
   You can peek in the progress of the pipeline by looking at the output from time to time:
 
@@ -317,7 +329,7 @@ power for the second part of the tutorial. For instance if you have 12 cores, pu
 
     tail minute_pipeline.out
 
-  It is important that you do this right away, to see if the pipeline is correctly running or there is some issue with it. Otherwise, if it crashes, it will do so silently.
+  It is important that you do this right away, to see if the pipeline is correctly running or there is some issue with it. Otherwise, if it crashes, it will print the error in the output files you speficied and you will not notice.
 
 
 .. note::
@@ -325,12 +337,15 @@ power for the second part of the tutorial. For instance if you have 12 cores, pu
 
   .. code-block:: bash
 
-    snakemake -p /proj/epi2022/minute_chip/minute/minute/Snakefile -j 4 --rerun-incomplete
+    minute run --rerun-incomplete > minute_pipeline.out 2> minute_pipeline.err &
+
+
+  This will overwrite the previous logs, so if you want to keep the previous ones, just use a different filename, like `minute_pipeline_rerun.out`.
 
 
 After the pipeline is run, you will have the following folders:
 
-- :code:`final/`: Contains final files: bigWig files, BAM files and demultiplexed FASTQ files (in this case, the same as your input).
+- :code:`final/`: Contains final files: bigWig files, BAM files and demultiplexed FASTQ files (in this case, the same as your input). If you ran the `no_bigwigs` option, this will not have bigWig files, but you can copy them later.
 - :code:`reports/`: Some reports on QC and scaling.
 - :code:`log/`: Log output from each step.
 - :code:`stats/`: Some stats files generated at each step.
@@ -376,7 +391,7 @@ Primed vs Naïve, information that is lost in unscaled files.
 
 
 .. note::
-  Make sure you select the scaled tracks together and click on *group autoscale* so all the scales match.
+  Make sure you select the scaled tracks together (CTRL + clicking on relevant track names), then right-click and select *group autoscale* so the scales are comparable.
 
 
 
@@ -403,8 +418,8 @@ Now you can get a copy of all the bigWig files + the bivalent annotation:
 
   mkdir bw
 
-  cp /proj/epi2022/minute_chip/downstream/*.bw bw/
-  cp /proj/epi2022/minute_chip/downstream/*.bed .
+  cp /sw/courses/epigenomics/quantitative_chip_simon/minute_tutorial/downstream/*.bw bw/
+  cp /sw/courses/epigenomics/quantitative_chip_simon/minute_tutorial/downstream/*.bed .
 
 
 There should be :code:`unscaled` and :code:`scaled` bigWig files, plus a set of genes marked as Bivalent: :code:`Bivalent_Court2017.hg38.bed`. This annotation
@@ -423,7 +438,7 @@ Looking at bivalent genes
 You can look at these using `deepTools <https://deeptools.readthedocs.io/en/develop/>`_. deepTools is a suite to process sequencing data.
 
 .. note::
-  If you just ran the primary analysis before, and you have an active :code:`minute_lab` conda environment, you probably don't need to load the deepTools module anyway. Otherwise, you can do:
+  If you just ran the primary analysis before, and you have an active :code:`minute` conda environment, you probably don't need to load the deepTools module anyway. Otherwise, you can do:
 
   .. code-block:: bash
 
@@ -537,7 +552,10 @@ We can make this a little more readable:
 
 .. code-block:: R
 
-  colnames(df) <- c(c("seqnames", "start", "end"), gsub("_pooled.hg38|.bw", "", colnames(df)[4:ncol(df)]))
+  colnames(df) <- c(
+    c("seqnames", "start", "end"),
+    gsub("_pooled.hg38|.bw", "", colnames(df)[4:ncol(df)])
+  )
 
   colnames(df)
 


### PR DESCRIPTION
A PR to make some fixes and improvements on the texts for the advanced ChIP tutorials:

* Added some missing references and reformatted them to the end of the section.
* Fixed paths to remove old 2022 references and update paths that have deliberately changed.
* Made some changes to the minute tutorial that can be installed from bioconda now, and is wrapped on a nice python script so it is not necessary to explicitly run Snakemake.
* Gave the tutorials a re-read and rewrote some things to be clearer.
