### PR TITLE
fix: data integration section

### DIFF
--- a/docs/content/tutorials/genomeOverlap/lab-genomicGoverlaps.md
+++ b/docs/content/tutorials/genomeOverlap/lab-genomicGoverlaps.md
@@ -8,15 +8,15 @@
 
 ### Table of contents
 - [Genomic overlaps](#genomic-overlaps)
-	- [Learning outcomes](#learning-outcomes)
-		- [Table of contents](#table-of-contents)
-	- [Setting up](#setting-up)
-	- [Introduction to genomic ranges](#introduction-to-genomic-ranges)
-		- [Operations on a single GRanges object](#operations-on-a-single-granges-object)
-		- [Comparing GRanges](#comparing-granges)
-	- [Statistical significance of overlaps](#statistical-significance-of-overlaps)
-	- [Example with insulator elements](#example-with-insulator-elements)
-		- [Different sampling methods](#different-sampling-methods)
+  - [Learning outcomes](#learning-outcomes)
+    - [Table of contents](#table-of-contents)
+  - [Setting up](#setting-up)
+  - [Introduction to genomic ranges](#introduction-to-genomic-ranges)
+    - [Operations on a single GRanges object](#operations-on-a-single-granges-object)
+    - [Comparing GRanges](#comparing-granges)
+  - [Statistical significance of overlaps](#statistical-significance-of-overlaps)
+  - [Example with insulator elements](#example-with-insulator-elements)
+    - [Different sampling methods](#different-sampling-methods)
 
 ## Setting up
 
@@ -221,17 +221,17 @@ ctcf.1 <- import.gff3("ctcf.gff3")
 
 allDataSets <- list(insv.2.6=insv.2.6,
                     insv.6.12=insv.6.12,
-		    beaf32=beaf32,
-		    cp190=cp190,
-		    ctcf.1=ctcf.1)
+                    beaf32=beaf32,
+                    cp190=cp190,
+                    ctcf.1=ctcf.1)
 
 # These data sets are from different studies, and on different formats. 
 # We have to make sure that they are all on the same format, so that all chromosome names match.
 lapply(allDataSets, seqlevelsStyle)
 
 for(i in 1:length(allDataSets)){
-	seqlevelsStyle(allDataSets[[i]])<-"UCSC"
-	allDataSets[[i]] <- filterChromosomes(allDataSets[[i]], organism = "dm3")
+    seqlevelsStyle(allDataSets[[i]])<-"UCSC"
+    allDataSets[[i]] <- filterChromosomes(allDataSets[[i]], organism = "dm3")
 }
 
 lapply(allDataSets, seqlevelsStyle)
@@ -246,9 +246,9 @@ overlapFraction <- matrix(NA, nrow=length(allDataSets), ncol=length(allDataSets)
 rownames(overlapFraction) <- names(allDataSets)
 colnames(overlapFraction) <- names(allDataSets)
 for(i in 1:length(allDataSets)){
-	for(j in 1:length(allDataSets)){
-		overlapFraction[i,j] <-	numOverlaps(A=allDataSets[[i]], B=allDataSets[[j]])/length(allDataSets[[i]])
-	}
+    for(j in 1:length(allDataSets)){
+        overlapFraction[i,j] <-	numOverlaps(A=allDataSets[[i]], B=allDataSets[[j]])/length(allDataSets[[i]])
+    }
 }
 round(overlapFraction,2)
 
@@ -273,9 +273,9 @@ overlapFraction <- matrix(NA, nrow=length(allDataSets), ncol=length(allDataSets)
 rownames(overlapFraction) <- names(allDataSets)
 colnames(overlapFraction) <- names(allDataSets)
 for(i in 1:length(allDataSets)){
-	for(j in 1:length(allDataSets)){
-		overlapFraction[i,j] <-	numOverlaps(A=allDataSets[[i]], B=allDataSets[[j]])/length(allDataSets[[i]])
-	}
+    for(j in 1:length(allDataSets)){
+        overlapFraction[i,j] <-	numOverlaps(A=allDataSets[[i]], B=allDataSets[[j]])/length(allDataSets[[i]])
+    }
 }
 round(overlapFraction,2)
 
@@ -300,29 +300,29 @@ colnames(overlapZ) <- names(allDataSets)
 nTimes <- 50
 
 for(i in 1:length(allDataSets)){
-	for(j in 1:length(allDataSets)){
-		if(i<j){
-			permRes <- overlapPermTest(A=allDataSets[[i]],
-			                           B=allDataSets[[j]], 
-						               ntimes=nTimes, 
-						               alternative="greater", 
-						               genome=getGenome(dm3), 
-						               mc.set.seed=FALSE, 
-						               verbose=FALSE)
-			overlapP[i,j] <- permRes$numOverlaps$pval
-			overlapZ[i,j] <- permRes$numOverlaps$zscore
-		}
-	}
+    for(j in 1:length(allDataSets)){
+        if(i<j){
+            permRes <- overlapPermTest(A=allDataSets[[i]],
+                                       B=allDataSets[[j]], 
+                                       ntimes=nTimes, 
+                                       alternative="greater", 
+                                       genome=getGenome(dm3), 
+                                       mc.set.seed=FALSE, 
+                                       verbose=FALSE)
+            overlapP[i,j] <- permRes$numOverlaps$pval
+            overlapZ[i,j] <- permRes$numOverlaps$zscore
+        }
+    }
 }
 
 # Fill in the missing values.
 for(i in 1:length(allDataSets)){
-	for(j in 1:length(allDataSets)){
-		if(i>j){
-			overlapP[i,j] <- overlapP[j,i]
-			overlapZ[i,j] <- overlapZ[j,i]
-		}
-	}
+    for(j in 1:length(allDataSets)){
+        if(i>j){
+            overlapP[i,j] <- overlapP[j,i]
+            overlapZ[i,j] <- overlapZ[j,i]
+        }
+    }
 }
 diag(overlapP) <- 0
 diag(overlapZ) <- NA
@@ -367,29 +367,29 @@ colnames(overlapZ) <- names(allDataSets)
 nTimes <- 500
 
 for(i in 1:length(allDataSets)){
-	for(j in 1:length(allDataSets)){
-		if(i<j){
-			permRes <- permTest(A=allDataSets[[i]], 
-			                    B=allDataSets[[j]], 
-					            ntimes=nTimes,
-					            randomize.function=resampleRegions, 
-					            universe=us,
-					            alternative="greater", evaluate.function=numOverlaps,
-					            count.once=TRUE, mc.set.seed=FALSE, mc.cores=4)
-			overlapP[i,j] <- permRes$numOverlaps$pval
-			overlapZ[i,j] <- permRes$numOverlaps$zscore
-		}
-	}
+    for(j in 1:length(allDataSets)){
+        if(i<j){
+            permRes <- permTest(A=allDataSets[[i]], 
+                                B=allDataSets[[j]], 
+                                ntimes=nTimes,
+                                randomize.function=resampleRegions, 
+                                universe=us,
+                                alternative="greater", evaluate.function=numOverlaps,
+                                count.once=TRUE, mc.set.seed=FALSE, mc.cores=4)
+            overlapP[i,j] <- permRes$numOverlaps$pval
+            overlapZ[i,j] <- permRes$numOverlaps$zscore
+        }
+    }
 }
 
 # Fill in the missing values.
 for(i in 1:length(allDataSets)){
-	for(j in 1:length(allDataSets)){
-		if(i>j){
-			overlapP[i,j] <- overlapP[j,i]
-			overlapZ[i,j] <- overlapZ[j,i]
-		}
-	}
+    for(j in 1:length(allDataSets)){
+        if(i>j){
+            overlapP[i,j] <- overlapP[j,i]
+            overlapZ[i,j] <- overlapZ[j,i]
+        }
+    }
 }
 diag(overlapP) <- 0
 diag(overlapZ) <- NA

--- a/docs/content/tutorials/genomeOverlap/lab-genomicGoverlaps.md
+++ b/docs/content/tutorials/genomeOverlap/lab-genomicGoverlaps.md
@@ -4,22 +4,25 @@
 
 - To be able to manipulate genomic ranges using the `GRanges` package.
 
-- To compute statistical significance of overlaps between two sets of genomic ranges using randomization tests, and to understand some of the pitfalls when interpreting stuch tests.
+- To compute statistical significance of overlaps between two sets of genomic ranges using randomization tests, and to understand some of the pitfalls when interpreting such tests.
 
 ### Table of contents
-  * [Setting up](#setting-up)
-  * [Introduction to genomic ranges](#introduction-to-genomic-ranges)
-    + [Operations on a single GRagnes object](#operations-on-a-single-gragnes-object)
-    + [Comparing GRanges](#comparing-granges)
-  * [Statistical significance of overlaps](#statistical-significance-of-overlaps)
-  * [Example with insulator elements](#example-with-insulator-elements)
-    + [Different sampling method](#different-sampling-method)
+- [Genomic overlaps](#genomic-overlaps)
+	- [Learning outcomes](#learning-outcomes)
+		- [Table of contents](#table-of-contents)
+	- [Setting up](#setting-up)
+	- [Introduction to genomic ranges](#introduction-to-genomic-ranges)
+		- [Operations on a single GRanges object](#operations-on-a-single-granges-object)
+		- [Comparing GRanges](#comparing-granges)
+	- [Statistical significance of overlaps](#statistical-significance-of-overlaps)
+	- [Example with insulator elements](#example-with-insulator-elements)
+		- [Different sampling methods](#different-sampling-methods)
 
 ## Setting up
 
-To run this exercise on uppmax, first load the following modules on uppmax:
+To run this exercise on Uppmax, first load the following modules on Uppmax:
 
-```{bash eval=FALSE}
+```bash
 module load bioinfo-tools
 module load R/4.0.0
 module load R_packages/4.0.0
@@ -27,13 +30,13 @@ module load RStudio
 module load samtools
 ```
 
-Then set up a working directory, in which you create links to all data files needed for the exercise, e.g with `ln -s /sw/courses/epigenomics/genomic_overlaps/* .`. 
+Then set up a working directory, in which you create links to all data files needed for the exercise, *e.g.* with `ln -s /sw/courses/epigenomics/genomic_overlaps/* .`. 
 
 Now start `R`, or `rstudio`.
 
 ## Introduction to genomic ranges
 
-Genomic regions can be used to represent the locations of many features on the genome, e.g. genes, enchancers, open chromatin, transcripsion factor binding sites, CpG islands, SNPs and more. Handling genomic regions is useful for a wide variety of bioinformatic applications. Some examples are:
+Genomic regions can be used to represent the locations of many features on the genome, *e.g.* genes, enchancers, open chromatin, transcripsion factor binding sites, CpG islands, SNPs and more. Handling genomic regions is useful for a wide variety of bioinformatic applications. Some examples are:
 
 - Find all promoter regions of a group of genes
 
@@ -50,19 +53,19 @@ We will start by looking at some methods to manipulate genomic ranges, using ChI
 We start by loading the libraries needed for this exercise.
 
 
-```
+```R
 library("rtracklayer")
 library("regioneR")
 library("BSgenome.Dmelanogaster.UCSC.dm3")
 library("pheatmap")
 ```
 
-Next, we load the first Insv data set. We use the function `import.bed`, which reads a file and returns a `GRanges` object. This holds information on one or more regions across a genome. Have a look at it. There are corresponding functions to load gff, bw and bedGraph files too. We also use the function `filterChromosomes` to remove special chromosomes present in the *Drosophila* genome, e.g. heterochromatin and a special "chromosome" made up of unassembled contigs.
+Next, we load the first Insv data set. We use the function `import.bed`, which reads a file and returns a `GRanges` object. This holds information on one or more regions across a genome. Have a look at it. There are corresponding functions to load `gff`, `bw` and `bedGraph` files too. We also use the function `filterChromosomes` to remove special chromosomes present in the *Drosophila* genome, *e.g.* heterochromatin and a special "chromosome" made up of unassembled contigs.
 
 
 *Can you understand the output? How many peaks does this data set have?* 
 
-```{r granges_intro1}
+```R
 set.seed(1234)
 
 insv.2.6 <- import.bed("insv_2_6h.bed")
@@ -77,12 +80,12 @@ length(insv.2.6)
 ```
 
 
-### Operations on a single GRagnes object
+### Operations on a single GRanges object
 
-There are several operations you can perform on a `Granges` object: shift al regions to the left or right, change their size, get flanking regions, merge overlapping regions, find everything not covered by the regions etc. Try out a few of these. *Do you understand what these functions do? Otherwise try e.g. `?flank`.*
+There are several operations you can perform on a `Granges` object: shift all regions to the left or right, change their size, get flanking regions, merge overlapping regions, find everything not covered by the regions etc. Try out a few of these. *Do you understand what these functions do? Otherwise try *e.g.* `?flank`.*
 
 
-```
+```R
 # Get flanking regions
 flank(insv.2.6, 10, start=TRUE)
 flank(insv.2.6, 10, start=FALSE)
@@ -104,11 +107,11 @@ gaps(insv.2.6)
 
 ### Comparing GRanges
 
-In integrating different data sets, it is often useful to compare several `GRanges` objects, to see how much they overlap, or where they differ. Here we load the other Insv data set, from 6-12 hour embryos, and compare it to the data from 2-6 hours. Since each peak is only represented by the 2 bp peak summit, we start by exteding the peaks so they are 500 bp, and merging overlapping peaks.
+When integrating different data sets, it is often useful to compare several `GRanges` objects, to see how much they overlap, or where they differ. Here, we load the other Insv data set, from 6-12 hour embryos, and compare it to the data from 2-6 hours. Since each peak is only represented by the 2 bp peak summit, we start by extending the peaks so they are 500bp, and merging overlapping peaks.
 
-Common operations for comparing two `GRanges` are: union (all sequence covered by any of the `GRanges` objects), intersect (all sequence covered by both of the `GRanges` objects), setdiff (all sequence covered by one `GRanges` object but not the other).
+Common operations for comparing two `GRanges` are: `union` (all sequence covered by any of the `GRanges` objects), `intersect` (all sequence covered by both of the `GRanges` objects), `setdiff` (all sequence covered by one `GRanges` object but not the other).
 
-```
+```R
 insv.6.12 <- import.bed("insv_6_12h.bed")
 insv.6.12 <- filterChromosomes(insv.6.12, organism = "dm3")
 insv.2.6 <- reduce(insv.2.6 + 249)
@@ -142,9 +145,9 @@ sum(width(setdiff(insv.2.6, insv.6.12)))
 sum(width(setdiff(insv.2.6, insv.6.12))) + sum(width(intersect(insv.2.6, insv.6.12)))
 ```
 
-If we have two data sets, the function `findOverlaps` calculates which of the regions in the two data sets that overlap.
+If we have two data sets, the function `findOverlaps` calculates which of the regions in the two data sets overlap.
 
-```
+```R
 # Which regions overlap?
 ol <- findOverlaps(insv.2.6, insv.6.12)
 ol
@@ -155,7 +158,7 @@ which(duplicated(queryHits(ol)))
 
 ## Statistical significance of overlaps
 
-Determining if two sets of genomic regions overlap more than expected by chance is a common problem in genomics. Here we will try the `regioneR` package to do this, but there are many other methods available. As you will see this is a quite difficult problen, and the results should be interpreted with caution.
+Determining if two sets of genomic regions overlap more than expected by chance is a common problem in genomics. Here we will try the `regioneR` package to do this, but there are many other methods available. As you will sees this is a quite difficult problem, and the results should be interpreted with caution.
 
 The `regioneR` package uses randomization tests to asses how significant the overlap between two data sets is. The basic idea is to:
 
@@ -165,14 +168,14 @@ The `regioneR` package uses randomization tests to asses how significant the ove
 
 3. Calculate the overlap between A and B'.
 
-4. Repeat steps 2 and 3 many times (e.g. 1000) to get a distribution of how many overlaps we would expect by chance.
+4. Repeat steps 2 and 3 many times (*e.g.* 1000) to get a distribution of how many overlaps we would expect by chance.
 
 5. Compare the results from step 1 (A vs B) to the results for all the randomized data sets. This makes it possible to calculate a p-value and a z-score. 
 
-To illustrate this, we create a data set of 100 regions, randomly ditributed across the genome. Using the test with 100 randomizations, we check if there is a signficant between the Insv peaks and our random data set. *How do you interpret the results?*
+To illustrate this, we create a data set of 100 regions, randomly ditributed across the genome. Using the test with 100 randomizations, we check if there is a significant between the Insv peaks and our random data set. *How do you interpret the results?*
 
 
-```
+```R
 # Read sizes of chromosomes
 dm3 <- read.table("dm3_chrom_sizes.txt")
 dm3 <- filterChromosomes(getGenome(dm3), organism="dm3")
@@ -187,7 +190,7 @@ plot(permRes)
 
 Using the same strategy, we can check if there is a significant overlap between the two Insv data sets, from different time points. *How do you interpret the results?*
 
-```
+```R
 permRes <- overlapPermTest(A=insv.2.6, B=insv.6.12, ntimes=100, alternative="greater", genome=getGenome(dm3), mc.set.seed=FALSE, verbose=TRUE)
 summary(permRes)
 plot(permRes)
@@ -199,7 +202,7 @@ plot(permRes)
 
 In [Dai et al. 2015](http://genesdev.cshlp.org/content/29/1/48.short) it was shown that Insv often binds together with insulator proteins (BEAF-32, CP190, CTCF and others) across the *Drosophila* genome. 
 
-Insulator elements were [first described](http://genesdev.cshlp.org/content/10/24/3202.abstract) as DNA elements that can restrict e.g. interactions between enhancers and target genes or the spread of heterochromatin.
+Insulator elements were [first described](http://genesdev.cshlp.org/content/10/24/3202.abstract) as DNA elements that can restrict *e.g.* interactions between enhancers and target genes or the spread of heterochromatin.
 
 ![(Hagstrom et al. 1996, Genes & Development)](hagstrom_insulator.png)
 
@@ -207,10 +210,10 @@ Later it was found that insulator elements control DNA looping, so that enhancer
 
 ![(Ali et al. 2016, Current Opinion in Genetics & Development)](ali_insulator.png)
 
-To check for ourselves if Insv overlaps isulator elements, we use some public data on insulator proteins, and compare these to the Insv regions. We start by loading and formatting data.
+To check if Insv overlaps insulator elements, we use some public data on insulator proteins, and compare these to the Insv regions. We start by loading and formatting the data.
 
 
-```
+```R
 # Add chr
 beaf32 <- import.gff3("beaf32.gff3")
 cp190 <- import.gff3("cp190.gff3")
@@ -235,10 +238,10 @@ lapply(allDataSets, seqlevelsStyle)
 ```
 
 
-Then, we simply count the overlaps between the various data sets. We loop though all pairs of data sets *i*,*j*, and coout the overlaps. In the matrix below each, entry *i,j,* represents the fraction of regions in data set *i* that overlap with data set *j*. We also plot the results as a heat map, where different levels of overlap are represented by different colors. *Does Insv overlap a lot woth the insulator proteins?*
+Then, we simply count the overlaps between the various data sets. We loop through all pairs of data sets *i*,*j*, and count the overlaps. In the matrix below each, entry *i,j,* represents the fraction of regions in data set *i* that overlap with data set *j*. We also plot the results as a heat map, where different levels of overlap are represented by different colors. *Does Insv overlap a lot with the insulator proteins?*
 
 
-```
+```R
 overlapFraction <- matrix(NA, nrow=length(allDataSets), ncol=length(allDataSets))
 rownames(overlapFraction) <- names(allDataSets)
 colnames(overlapFraction) <- names(allDataSets)
@@ -257,7 +260,7 @@ pheatmap(overlapFraction, cluster_rows=FALSE, cluster_cols=FALSE, color = useCol
 For comparison, we add data on an unrelated transcription factor, CtBP, and re-run the analysis. *How much does Insv overlap the insulator proteins BEAF-32, CP190 and CTCT, compared to CtBP?*
 
 
-```
+```R
 # Load and format CtBp data
 ctbp <- import.bed("ctbp.bed")
 seqlevelsStyle(ctbp)<-"UCSC"
@@ -280,12 +283,12 @@ useCols <- colorRampPalette(c("white", "red"))(100)
 pheatmap(overlapFraction, cluster_rows=FALSE, cluster_cols=FALSE, color = useCols, main="% overlap")
 ```
 
-We can now check if the overlaps between the different proteins are more common than would be expected by chance. Again, we loop though all pairs of data sets *i*,*j*, but this this we do a randomization test for each pair *i*,*j*, and save the p-values and z-scores. Because this takes a while to run, we only use 50 randomization rounds. (To reduce runtime even more, we only compare each pair of data sets once and don't compare data sets to themselves.)
+We can now check if the overlaps between the different proteins are more common than would be expected by chance. Again, we loop through all pairs of data sets *i*,*j*, but this time we do a randomization test for each pair *i*,*j*, and save the p-values and z-scores. Because this takes a while to run, we only use 50 randomization rounds. (To reduce runtime even more, we only compare each pair of data sets once and don't compare data sets to themselves.)
 
 Looking at the p-values is not very informative, since they are all quite low. To get even lower p-values, we would have to run a lot more randomization rounds, which takes time. (P-values of 1e5 would require 100000 randomizations.) In this case, Z-scores are more informative, since they can provide a measure of how much bigger the overlap between data sets is, compared to randomized data.
 
 
-```{r overlap_significance}
+```R
 overlapP <- matrix(NA, nrow=length(allDataSets), ncol=length(allDataSets))
 rownames(overlapP) <- names(allDataSets)
 colnames(overlapP) <- names(allDataSets)
@@ -299,13 +302,13 @@ nTimes <- 50
 for(i in 1:length(allDataSets)){
 	for(j in 1:length(allDataSets)){
 		if(i<j){
-			permRes <- overlapPermTest(A=allDataSets[[i]], 
-                                                   B=allDataSets[[j]], 
-						   ntimes=nTimes, 
-						   alternative="greater", 
-						   genome=getGenome(dm3), 
-						   mc.set.seed=FALSE, 
-						   verbose=FALSE)
+			permRes <- overlapPermTest(A=allDataSets[[i]],
+			                           B=allDataSets[[j]], 
+						               ntimes=nTimes, 
+						               alternative="greater", 
+						               genome=getGenome(dm3), 
+						               mc.set.seed=FALSE, 
+						               verbose=FALSE)
 			overlapP[i,j] <- permRes$numOverlaps$pval
 			overlapZ[i,j] <- permRes$numOverlaps$zscore
 		}
@@ -333,16 +336,16 @@ pheatmap(overlapZ, cluster_rows=FALSE, cluster_cols=FALSE, color = useCols, main
 ```
 
 
-### Different sampling method
+### Different sampling methods
 
 When testing if the overlap between two data sets is significant, there are many choices that could have a big impact on the results. For example, most transcription factor binding sites are enriched around transcription start sites (TSS). This means that if we use a randomization strategy where we can place regions over the entire genome, we might overestimate the significance of the overlaps.
 
-Below, we check if results change if we instead focus on promoter regions only. For this we load coordinates of promoter regions, here defined as [TSS-1500, TSS+500]. We then only consider binding sites that fall within the prometer regions. As you can see, we still retain most binding sites. In the resampling strategy, we now only now **sample promoter regions instead of sampling random regions across the genome**. *How does this affect the results?*
+Below, we check whether the results change if we instead focus on promoter regions only. For this, we load coordinates of promoter regions, here defined as [TSS-1500, TSS+500]. We then only consider binding sites that fall within the prometer regions. As you can see, we still retain most binding sites. In this re-sampling strategy, we now only **sample promoter regions instead of sampling random regions across the genome**. *How does this affect the results?*
 
-(Since this randomization strategy is faster than sampling random regions, we now use 500 radnomization rounds.)
+(Since this randomization strategy is faster than sampling random regions, we now use 500 randomization rounds.)
 
 
-```
+```R
 # Load promoter regions
 us <- import.bed("genes1000bpupstream.bed") + 500
 seqlevelsStyle(us)<-"UCSC"
@@ -368,11 +371,11 @@ for(i in 1:length(allDataSets)){
 		if(i<j){
 			permRes <- permTest(A=allDataSets[[i]], 
 			                    B=allDataSets[[j]], 
-					    ntimes=nTimes,
-					    randomize.function=resampleRegions, 
-					    universe=us,
-					    alternative="greater", evaluate.function=numOverlaps,
-					    count.once=TRUE, mc.set.seed=FALSE, mc.cores=4)
+					            ntimes=nTimes,
+					            randomize.function=resampleRegions, 
+					            universe=us,
+					            alternative="greater", evaluate.function=numOverlaps,
+					            count.once=TRUE, mc.set.seed=FALSE, mc.cores=4)
 			overlapP[i,j] <- permRes$numOverlaps$pval
 			overlapZ[i,j] <- permRes$numOverlaps$zscore
 		}

--- a/docs/content/tutorials/scAtacSeq/lab-sc_atac_seq.md
+++ b/docs/content/tutorials/scAtacSeq/lab-sc_atac_seq.md
@@ -2,39 +2,41 @@
 
 ## Learning outcomes
 
-- Being able to run the basic the steps for quality control, normalization, dimensionality reduction, clustering and visualization of single cell ATAC-seq data
+- Being able to run the basic steps for quality control, normalization, dimensionality reduction, clustering and visualization of single cell ATAC-seq data
 
 - Being able to combine single cell ATAC-seq data with RNA-seq data, to better infer cell types.
 
-- Being able to run the basic the steps for quality control, normalization, dimensionality reduction, clustering and visualization of single cell multio-omics (RNA-seq + ATAC-seq) data
+- Being able to run the basic steps for quality control, normalization, dimensionality reduction, clustering and visualization of single cell multio-omics (RNA-seq + ATAC-seq) data
 
 
 **Table of contents**
 
-  * [Setting up](#setting-up)
-    + [Backup method for setting up](#backup-method-for-setting-up)
-  * [Analysis of single cell ATAC-seq data](#analysis-of-single-cell-atac-seq-data)
-    + [Loading scATAC-seq data](#loading-scatac-seq-data)
-    + [Quality control](#quality-control)
-    + [Normalization and intial dimensionality reduction.](#normalization-and-intial-dimensionality-reduction)
-    + [Clustering and further dimensionality reduction](#clustering-and-further-dimensionality-reduction)
-    + [Motif analysis](#motif-analysis)
-      - [Identifying enriched motifs](#identifying-enriched-motifs)
-      - [Motif activity scores](#motif-activity-scores)
-  * [Integrate with scRNA-seq data](#integrate-with-scrna-seq-data)
-    + [Gene activity matrix](#gene-activity-matrix)
-    + [Label transfer](#label-transfer)
-    + [Differentially accessible regions, again](#differentially-accessible-regions--again)
-    + [Annotating regions](#annotating-regions)
-    + [Visualization](#visualization)
-  * [Analysis of multi-omics data](#analysis-of-multi-omics-data)
+- [Integrating scATAC-seq and scRNA-seq data](#integrating-scatac-seq-and-scrna-seq-data)
+	- [Learning outcomes](#learning-outcomes)
+	- [Setting up](#setting-up)
+		- [Backup method for setting up](#backup-method-for-setting-up)
+	- [Analysis of single cell ATAC-seq data](#analysis-of-single-cell-atac-seq-data)
+		- [Loading scATAC-seq data](#loading-scatac-seq-data)
+		- [Quality control](#quality-control)
+		- [Normalization and intial dimensionality reduction](#normalization-and-intial-dimensionality-reduction)
+		- [Clustering and further dimensionality reduction](#clustering-and-further-dimensionality-reduction)
+		- [Motif analysis](#motif-analysis)
+			- [Identifying enriched motifs](#identifying-enriched-motifs)
+			- [Motif activity scores](#motif-activity-scores)
+	- [Integrate with scRNA-seq data](#integrate-with-scrna-seq-data)
+		- [Gene activity matrix](#gene-activity-matrix)
+		- [Label transfer](#label-transfer)
+		- [Differentially accessible regions, again](#differentially-accessible-regions-again)
+		- [Annotating regions](#annotating-regions)
+		- [Visualization](#visualization)
+	- [Analysis of multi-omics data](#analysis-of-multi-omics-data)
 
 
 ## Setting up
 
-The easiest way to run this exercise, which we highly recommend, is on Uppmax. Do do this, start an interactive session like you have done for the previous days, and then do
+The easiest way to run this exercise, which we highly recommend, is on Uppmax. To do this, start an interactive session like you have done for the previous days, and then do
 
-```
+```bash
 cd <some directory where you work with this course>
 
 mkdir -p sc_lab/data
@@ -55,12 +57,12 @@ Now you should be ready to go!
 
 ### Backup method for setting up
 
-If this doesn't work for some reason (e.g. if you don't have an account on uppmax), you can run the exercise on your laptop. This has been tested on Mac, but chances are that is also works on Linux and Windows. Also note that R uses around 13Gb RAM running the commands in the exercise.
+If this doesn't work for some reason (*e.g.* if you don't have an account on uppmax), you can run the exercise on your laptop. This has been tested on Mac, but chances are that it also works on Linux and Windows. Also note that R uses around 13Gb RAM running the commands in the exercise.
 
 First, set up the directory where you will work
 
 
-```
+```bash
 cd <some directory where you work with this course>
 
 mkdir -p sc_lab/data
@@ -69,16 +71,16 @@ cd sc_lab/data
 
 Install mamba, following the instructions [here](https://mamba.readthedocs.io/en/latest/micromamba-installation.html). Then, set up the environment using the commands below. This takes approximately one hour, depending on your network connection:
 
-```
-curl https://raw.githubusercontent.com/NBISweden/workshop-epigenomics-RTDs/master/docs/content/tutorials/scAtacSeq/environment_epigenomics2023.yml > environment_epigenomics2023.yml
+```bash
+curl https://raw.githubusercontent.com/NBISweden/workshop-epigenomics-RTDs/master/docs/content/tutorials/scAtacSeq/environment_epigenomics2023.yaml > environment_epigenomics2023.yaml
 
 mamba env create -n environment_epigenomics2023 -f environment_epigenomics2023.yaml
 ```
  
 NOTE: The commands above don't work with new Macs with the new Apple chips (M1, M2 etc.). If you have a Mac from 2021 or later, instead run:
 
-```
-curl https://raw.githubusercontent.com/NBISweden/workshop-epigenomics-RTDs/master/docs/content/tutorials/scAtacSeq/environment_epigenomics2023.yml > environment_epigenomics2023.yml
+```bash
+curl https://raw.githubusercontent.com/NBISweden/workshop-epigenomics-RTDs/master/docs/content/tutorials/scAtacSeq/environment_epigenomics2023.yaml > environment_epigenomics2023.yaml
 
 curl https://raw.githubusercontent.com/fasterius/dotfiles/main/scripts/intel-conda-env.sh > intel-conda-env.sh
 
@@ -89,7 +91,7 @@ chmod a+x intel-conda-env.sh
 
 Next download the data needed for the exercise (5.4 Gb, make sure you delete the files when you no longer need them):
 
-```
+```bash
 # download data for exercise
 curl -OJ https://export.uppmax.uu.se/naiss2023-23-349/sc_atac_seq/atac_v1_pbmc_10k_filtered_peak_bc_matrix.h5
 curl -OJ https://export.uppmax.uu.se/naiss2023-23-349/sc_atac_seq/atac_v1_pbmc_10k_fragments.tsv.gz
@@ -107,7 +109,7 @@ cd ..
 
 Finally, activate the environment and start Rstudio. If everything has worked, Rstudio should show up on your screen.
 
-```
+```bash
 mamba activate environment_epigenomics2023
 open -na Rstudio
 ```
@@ -117,16 +119,16 @@ If everything has worked, you should now see Rstudio, and can start the exercise
 
 ## Analysis of single cell ATAC-seq data
 
-[Seurat](https://satijalab.org/seurat/) is the most widley used tool to analyze scRNA-seq data. Recently, this R package has been extended to support chromatin data, e.g. ATAC. This extension package is called [Signac](https://satijalab.org/signac/index.html). Seurat makes it possbile to integrate data from different technologies. Here, we will look at how Seurat and Signac can be used to integrate scATAC-seq and scRNA-seq data. This exercise is based on [this](https://stuartlab.org/signac/articles/pbmc_vignette), [this](https://satijalab.org/seurat/articles/atacseq_integration_vignette) and [this](https://stuartlab.org/signac/articles/motif_vignette) tutorial, using data on human peripheral blood mononuclear cells (PBMCs) provided by 10x Genomics. We will use data that have already been pre-processed using CellRanger. The starting point is a count matrix, with the number of reads in each peak in each cell, along with some meta data.
+[Seurat](https://satijalab.org/seurat/) is the most widley used tool to analyze scRNA-seq data. Recently, this R package has been extended to support chromatin data, *e.g.* ATAC. This extension package is called [Signac](https://satijalab.org/signac/index.html). `Seurat` makes it possbile to integrate data from different technologies. Here, we will look at how `Seurat` and `Signac` can be used to integrate scATAC-seq and scRNA-seq data. This exercise is based on [this](https://stuartlab.org/signac/articles/pbmc_vignette), [this](https://satijalab.org/seurat/articles/atacseq_integration_vignette) and [this](https://stuartlab.org/signac/articles/motif_vignette) tutorial, using data on human peripheral blood mononuclear cells (PBMCs) provided by 10x Genomics. We will use data that have already been pre-processed using CellRanger. The starting point is a count matrix, with the number of reads in each peak in each cell, along with some meta data.
 
-We start by loading the required packages: Seurat, Signac, some annotation packages and some packages for plotting.
+We start by loading the required packages: `Seurat`, `Signac`, some annotation packages and some packages for plotting.
 
 ![George Seurat, 1859-1891](Seurat-Gravelines-Annonciade.jpg)
 
 ![Paul Signac, 1863-1935](Paul_signac,_la_barca_a_vela_verde,_1904,_01.jpg)
 
 
-```
+```R
 library(Signac)
 library(Seurat)
 library(GenomeInfoDb)
@@ -156,13 +158,13 @@ The ATAC-seq data consists of four files, that are created with CellRanger.
 
 - An index file connected to the fragment file. This is like an index file for a bam file, to make it possible to quickly find fragments for a certain genomic region, without having to search the entire file.
 
-The PBMC data set contains ATAC-seq data on 74836 regions in 9277 cells. The corresponding RNA-seq data covers 19089 genes in 9432 cells. To make the commands in this exercise run a bit faster, we will only analyze a set of 2000 (randomly selected) cells. If you have the time and interest, you can analyze the full data set, but commenting out the corresponding line of code.
+The PBMC data set contains ATAC-seq data on 74836 regions in 9277 cells. The corresponding RNA-seq data covers 19089 genes in 9432 cells. To make the commands in this exercise run a bit faster, we will only analyze a set of 2000 (randomly selected) cells. If you have the time and interest, you can analyze the full data set by commenting out the corresponding line of code.
 
-Here we create a `ChromatinAssay` object from the count matrix (and a link to the fragment file). This object stores the genomic regions, count data, and also possibly gene annotations and information on sequence motifs. There are many ways to interact with a `ChromatinAssay` object, see [this](https://stuartlab.org/signac/articles/data_structures.html) vignette.
+Here, we create a `ChromatinAssay` object from the count matrix (and a link to the fragment file). This object stores the genomic regions, count data, and also possibly gene annotations and information on sequence motifs. There are many ways to interact with a `ChromatinAssay` object, see [this](https://stuartlab.org/signac/articles/data_structures.html) vignette.
 
 We then create a `Seurat` object from the `ChromatinAssay`, together with meta data about cells and gene annotations.
 
-```
+```R
 counts <- Read10X_h5(filename = "data/atac_v1_pbmc_10k_filtered_peak_bc_matrix.h5")
 counts <- counts[, sample(ncol(counts), 2000)] # Only use 2000 cells, to make commands run faster.
 
@@ -207,19 +209,19 @@ granges(pbmc)
 
 The next step is to do some quality control (QC) on the ATAC-seq data. There are several qualtiy measures to consider:
 
-- **Fragment sizes**, determined from paired-end sequencing data. For each cell we can quantify the fragment sizes by calculaing the ratio of nucleosome size fragments (147-294 nucleotides) to nucleosome-free fragments (<147 nucleotides). Open chromatin correseponds to short DNA fragmens, so we want to remove cells with to few short DNA fragments, coming from open open chromatin.
+- **Fragment sizes**, determined from paired-end sequencing data. For each cell we can quantify the fragment sizes by calculating the ratio of nucleosome size fragments (147-294 nucleotides) to nucleosome-free fragments (<147 nucleotides). Open chromatin corresponds to short DNA fragments, so we want to remove cells with too few short DNA fragments, coming from open chromatin.
 
-- **Enrichment at transcription start sites (TSS).** Since chromatin is often open around TSS, we expect there to be an enrichment of framgents around these sites. This is quantified by collecting all fragments mapping around TSS to form an aggregate distribution, and comparing the highest level of fragments to the level of fragments 1000bp up and downstream of the TSS.
+- **Enrichment at transcription start sites (TSS).** Since chromatin is often open around TSS, we expect there to be an enrichment of fragments around these sites. This is quantified by collecting all fragments mapping around TSS to form an aggregate distribution, and comparing the highest level of fragments to the level of fragments 1000bp up and downstream of the TSS.
 
 - **Number of fragments in peaks**. This represents the complexity and sequencing depth for each cell. Too many reads might indicate artefacts, such as several cells sharing a barcode.
 
-- **Fraction of reads in peaks**. This represents how well that ATAC protocol has worked, and we typically reqiure at least 15% if all fragments to be in peaks.
+- **Fraction of reads in peaks**. This represents how well that ATAC protocol has worked, and we typically reqiure at least 15% of all fragments to be in peaks.
 
 - **Reads in blacklist regions.** The [ENCODE](https://www.encodeproject.org) project has defined lists of [blacklist regions](https://github.com/Boyle-Lab/Blacklist). These are problematic regions (typically repeats) that often have high signals in next-generation sequencing experiments regardless of cell line or experiment. Cells with a realtively high ratio of reads mapping to blacklist regions, compared to peaks, often represent technical artifacts and should be removed.
 
-This talkes a while to run (around 10 minutes).
+This takes a while to run (around 10 minutes).
 
-```{r seurat_qc}
+```R
 # Compute nucleosome signal score per cell
 pbmc <- NucleosomeSignal(object = pbmc)
 
@@ -237,16 +239,16 @@ TSSPlot(pbmc, group.by = 'high.tss') + NoLegend()
 ```
 
 
-```
+```R
 pbmc$nucleosome_group <- ifelse(pbmc$nucleosome_signal > 4, 'NS > 4', 'NS < 4')
 FragmentHistogram(object = pbmc, group.by = 'nucleosome_group')
 ```
 
-```
+```R
 VlnPlot(
 	object = pbmc,
 	features = c('pct_reads_in_peaks', 'peak_region_fragments',
-							 'TSS.enrichment', 'blacklist_ratio', 'nucleosome_signal'),
+				 'TSS.enrichment', 'blacklist_ratio', 'nucleosome_signal'),
 	pt.size = 0.1,
 	ncol = 3
 )
@@ -254,10 +256,10 @@ VlnPlot(
 
 ![QC plots](qc.png)
 
-After calculating the qualtiy statistics, we apply (some rather artibtrary) cutoffs, to remove outlier cells. *How many cells do we have left after quality filtering in this example?*
+After calculating the qualtiy statistics, we apply (some rather arbitrary) cutoffs, to remove outlier cells. *How many cells do we have left after quality filtering in this example?*
 
 
-```
+```R
 pbmc <- subset(
 	x = pbmc,
 	subset = peak_region_fragments > 3000 &
@@ -271,17 +273,17 @@ pbmc
 ```
 
 
-### Normalization and intial dimensionality reduction.
+### Normalization and intial dimensionality reduction
 
-**Normalization:** Signac performs term frequency-inverse document frequency (TF-IDF) normalization. This is a two-step normalization procedure, often used in natural language processing, that both normalizes across cells to correct for differences in sequencing depth, and across peaks to give higher values to more rare peaks.
+**Normalization:** `Signac` performs term frequency-inverse document frequency (TF-IDF) normalization. This is a two-step normalization procedure, often used in natural language processing, that both normalizes across cells to correct for differences in sequencing depth, and across peaks to give higher values to more rare peaks.
 
-**Feature selection:** To reduce noise, we sometimes only use some features (i.e. peaks) when we cluster cells. Often this is the peaks with the strongest signal, i.e. most reads, or the ones present in most cells. Here, we will use all peaks, but you can play around with this yourself. Try setting min.cutoff to ‘q75’ to use the top 25% peaks).
+**Feature selection:** To reduce noise, we sometimes only use some features (*i.e.* peaks) when we cluster cells. Often this is the peaks with the strongest signal, *i.e.* most reads, or the ones present in most cells. Here, we will use all peaks, but you can play around with this yourself. Try setting `min.cutoff = 'q75'` to use the top 25% peaks).
 
 **Dimension reduction:** We next run singular value decomposition (SVD) on the normalized data matrix, using the features (peaks) selected above. This returns a reduced dimension representation of the matrix, similar to the output of PCA.
 
-From the singular value decomposition, we get a set of components. The first of these components often correlates with seuquencing depth, rather than any biologically meaningful signal. We can therefore remove this component in the following analysis.
+From the singular value decomposition, we get a set of components. The first of these components often correlates with sequencing depth, rather than any biologically meaningful signal. We can therefore remove this component in the following analysis.
 
-```
+```R
 pbmc <- RunTFIDF(pbmc)
 pbmc <- FindTopFeatures(pbmc, min.cutoff = 'q0')
 pbmc <- RunSVD(pbmc)
@@ -291,9 +293,9 @@ DepthCor(pbmc)
 
 ### Clustering and further dimensionality reduction
 
-Now we can cluster the cells to find groups that belong to the same cell types. It is possible to plot the results from the SVD, but these often are not informative. Instead, we use the UMAP algorithm, which shows a better separation between the cell types. If you are interested, the paper describing UMAP can be found [here](https://arxiv.org/abs/1802.03426)
+Now, we can cluster the cells to find groups that belong to the same cell types. It is possible to plot the results from the SVD, but these often are not informative. Instead, we use the UMAP algorithm, which shows a better separation between the cell types. If you are interested, the paper describing UMAP can be found [here](https://arxiv.org/abs/1802.03426).
 
-```{r seurat_umap}
+```R
 pbmc <- RunUMAP(object = pbmc, reduction = 'lsi', dims = 2:34)
 pbmc <- FindNeighbors(object = pbmc, reduction = 'lsi', dims = 2:34, k.param=13)
 pbmc <- FindClusters(object = pbmc, verbose = FALSE)
@@ -315,21 +317,21 @@ p1 | p2
 This might be a good time to save your data, so you don't have to re-run all your analysis if you have problems with Uppmax or the network. To load the data later, type `load(file="pbmc.Rda")`.
 
 
-```
+```R
 save(pbmc, file="pbmc.Rda")
 ```
 
 ### Motif analysis
 
-We can also analyze motif occurence in the peaks, to see how this varies between the different cell types.
+We can also analyze motif occurrence in the peaks, to see how this varies between the different cell types.
 
 #### Identifying enriched motifs
 
-First we will look at motifs that are enriched in a set of peaks, e.g. in peaks that show differential accessibility between two cell types. *Do you notice anything particular about these motifs?*
+First, we will look at motifs that are enriched in a set of peaks, *e.g.* in peaks that show differential accessibility between two cell types. *Do you notice anything particular about these motifs?*
 
 
 
-```{r enriched_motifs}
+```R
 # Get a list of motif position frequency matrices from the JASPAR database
 pfm <- getMatrixSet(
 	x = JASPAR2020,
@@ -348,7 +350,7 @@ as.matrix(motif.matrix[1:10,1:10])
 ```
 
 
-```
+```R
 # Create a new Mofif object to store the results
 motif <- CreateMotifObject(
 	data = motif.matrix,
@@ -390,7 +392,7 @@ enriched.motifs <- FindMotifs(
 head(enriched.motifs)
 ```
 
-```
+```R
 # Have a look at the most enriched motifs. Do you anything particular about these motifs?
 MotifPlot(
 	object = pbmc,
@@ -400,13 +402,13 @@ MotifPlot(
 
 #### Motif activity scores
 
-We can also compute a per-cell motif activity score by running chromVAR. The motif activity score for a motif M is based on the on number of reads mapping to peaks with motif M, after normalization correction for various biases: GC content, average number of reads mapping across all cells etc. You can read more about chromVar [here](https://www.nature.com/articles/nmeth.4401). Motif activity scores allow us to visualize motif activities per cell.
+We can also compute a per-cell motif activity score by running chromVAR. The motif activity score for a motif M is based on the number of reads mapping to peaks with motif M, after normalization correction for various biases: GC content, average number of reads mapping across all cells etc. You can read more about chromVar [here](https://www.nature.com/articles/nmeth.4401). Motif activity scores allow us to visualize motif activities per cell.
 
 It is also possible to directly test for differential activity scores between cell types, without looking at peaks with differential binding. This tends to give similar results as performing an enrichment test on differentially accessible peaks between the cell types (shown above).
 
 This takes a while to run (around 5 minutes on Uppmax).
 
-```{r chromvar}
+```R
 # Use chromVAR to calculate the motif activities of all motifs in all cells.
 pbmc <- RunChromVAR(
 	object = pbmc,
@@ -430,8 +432,7 @@ FeaturePlot(
 ```
 
 
-```
-
+```R
 # Look for motifs that have differential activity between clusters 0 and 1.
 differential.activity <- FindMarkers(
 	object = pbmc,
@@ -456,7 +457,7 @@ MotifPlot(
 
 ## Integrate with scRNA-seq data
 
-In this section we will compare the scATAC-seq data to scRNA-seq data from a similar starting material (although not from exatcly the same cells). Since it is easier to figure out which cell types clusters correspond to in scRNA-seq data, we will then use the scRNA-seq data to annotate the clusters in the scATAC-seq data. (Note that if you have multiomics data, with RNA-seq and ATAC-seq from the same cells, you don't need to take the extra detour to gene activity scores, but can use instead your RNA-seq data to annotate cell types.)
+In this section, we will compare the scATAC-seq data to scRNA-seq data from a similar starting material (although not from exatcly the same cells). Since it is easier to figure out which cell types clusters correspond to in scRNA-seq data, we will then use the scRNA-seq data to annotate the clusters in the scATAC-seq data. (Note that if you have multi-omics data, with RNA-seq and ATAC-seq from the same cells, you don't need to take the extra detour to gene activity scores, but can use instead your RNA-seq data to annotate cell types.)
 
 ### Gene activity matrix
 
@@ -464,7 +465,7 @@ Gene activity scores capture how much open chromatin there is in the promoter re
 
 Calculating the gene activity scores takes around 10 minutes for 2000 cells and all genes.
 
-```
+```R
 DefaultAssay(pbmc) <- 'peaks'
 
 gene.activities <- GeneActivity(pbmc)
@@ -481,7 +482,7 @@ GetAssayData(pbmc$RNA)[1:10,1:3]
 ```
 
 
-```
+```R
 DefaultAssay(pbmc) <- 'RNA'
 FeaturePlot(
 	object = pbmc,
@@ -499,13 +500,13 @@ FeaturePlot(
 
 Having computed the gene activity scores, we are now ready to combine the ATAC-seq data with the RNA-seq data.
 
-We start by finding anchors, i.e. paris of cells, one from ATAC-seq and one from RNA-seq. This is done by first projecting bort ATAC-seq and RNA-seq data into the same space, and then find pairs of cells one from ATAC-seq and the other from RNA-seq that are mutual nearest neighbors (MNNs). These are further filtered and the reliable pairs are the used as anchors.
+We start by finding anchors, *i.e.* pairs of cells, one from ATAC-seq and one from RNA-seq. This is done by first projecting ATAC-seq and RNA-seq data into the same space, and then find pairs of cells one from ATAC-seq and the other from RNA-seq that are mutual nearest neighbors (MNNs). These are further filtered and the reliable pairs are then used as anchors.
 
 These anchors can then be used to project the ATAC-seq data onto the RNA-seq data and find the cell type annotation of the nearby cells. This way annotations from the RNA-seq data can be transferred to the ATAC-seq data. This is sometimes referred to as **label transfer**.
 
 *How well do you think this worked? Can you see if some cells types are missing or merged?*
 
-```
+```R
 # Load the pre-processed scRNA-seq data for PBMCs
 pbmc_rna <- readRDS("data/pbmc_10k_v3.rds")
 
@@ -567,10 +568,10 @@ pbmc <- RenameIdents(
 
 ### Differentially accessible regions, again
 
-Now, we will once again look at differentially accessible region, this time between *CD4/8 Naive* cells and *CD14 Mono* cells (since we now can say what cell types these clusters represent.) We can plot the signal in this region in a couple of different ways. *Do you understand what these plots mean?*
+Now, we will once again look at differentially accessible regions, this time between *CD4/8 Naive* cells and *CD14 Mono* cells (since we now can say what cell types these clusters represent.) We can plot the signal in this region in a couple of different ways. *Do you understand what these plots mean?*
 
 
-```{r seurat_diff_peaks}
+```R
 # Change back to working with peaks instead of gene activities
 DefaultAssay(pbmc) <- 'peaks'
 
@@ -586,7 +587,7 @@ da_peaks <- FindMarkers(
 head(da_peaks)
 ```
 
-```
+```R
 # Plot the signal for the most differentially acessable region.
 plot1 <- VlnPlot(
 	object = pbmc,
@@ -606,9 +607,9 @@ plot1 | plot2
 
 ### Annotating regions
 
-Genomic coordinates are difficult to interpret on their own, and often it is interesting to know which genes are near, or at, the genomic regions. Below we find the nearest gene, and the distance to it, for each region. This makes it easy to check for regions near genes of interest, and to analyze genes further, e.g though a Gene Ontology analysis.
+Genomic coordinates are difficult to interpret on their own, and often it is interesting to know which genes are near or at the genomic regions. Below, for each region, we find the nearest gene and the distance to it. This makes it easy to check for regions near genes of interest, and to analyze genes further, *e.g.* through a Gene Ontology analysis.
 
-```{r seurat_peak_annot}
+```R
 open_cd4naive <- rownames(da_peaks[da_peaks$avg_log2FC > 0.5, ])
 open_cd14mono <- rownames(da_peaks[da_peaks$avg_log2FC < -0.5, ])
 
@@ -619,10 +620,11 @@ head(closest_genes_cd14mono)
 ```
 
 ### Visualization
-It is often informative to plot the ATAC-seq signal for a particular genomic region, and group this by cluster, cell type or some other meta data. We can either plot the the aggregate signal for a group with `coveragePlot` or the signal for individual cells, with `tilePlot`. More info about plotting genomic region can be found [here](https://satijalab.org/signac/articles/visualization.html)
+
+It is often informative to plot the ATAC-seq signal for a particular genomic region, and group this by cluster, cell type or some other meta data. We can either plot the aggregate signal for a group with `coveragePlot` or the signal for individual cells, with `tilePlot`. More info about plotting genomic region can be found [here](https://satijalab.org/signac/articles/visualization.html).
 
 
-```
+```R
 CoveragePlot(
 	object = pbmc,
 	region = rownames(da_peaks)[1],
@@ -632,7 +634,7 @@ CoveragePlot(
 )
 ```
 
-```
+```R
 TilePlot(
 	object = pbmc,
 	region = rownames(da_peaks)[1],
@@ -645,19 +647,19 @@ TilePlot(
 
 ## Analysis of multi-omics data
 
-Recently single cell multi-omics methods that run several assays on the same cells have become available. One such method is [Chromium Single Cell Multiome from 10X genomics](https://www.10xgenomics.com/products/single-cell-multiome-atac-plus-gene-expression), which simultaneously measures gene expression (RNA-seq) and chromatin accessibility (ATAC-seq) in the same nuclei. This makes it possible to identift cell types and states based on both gene expression and accessibility. It also makes it easy to use external gene expression data to annotate your cells, and at the same time study the chromatin accessibility in the cells. In this exercise, we will look at a public data set downloaded from 10X genomics, from [embyomic mouse brain](https://www.10xgenomics.com/resources/datasets/fresh-embryonic-e-18-mouse-brain-5-k-1-standard-2-0-0). You will load both the RNA-seq and ATAC-seq data into the same seurat object and do some simple pre-processing like in for the ATAC-seq data above. Then you will run joint clustering and visuaization of the of the combined data set, and finally use the gene expression measurements together with a public data set to annotate the cells.
+Recently, single cell multi-omics methods that run several assays on the same cells have become available. One such method is [Chromium Single Cell Multiome from 10X genomics](https://www.10xgenomics.com/products/single-cell-multiome-atac-plus-gene-expression), which simultaneously measures gene expression (RNA-seq) and chromatin accessibility (ATAC-seq) in the same nuclei. This makes it possible to identify cell types and states based on both gene expression and accessibility. It also makes it easy to use external gene expression data to annotate your cells, and at the same time study the chromatin accessibility in the cells. In this exercise, we will look at a public data set downloaded from 10X genomics, from [embyomic mouse brain](https://www.10xgenomics.com/resources/datasets/fresh-embryonic-e-18-mouse-brain-5-k-1-standard-2-0-0). You will load both the RNA-seq and ATAC-seq data into the same `Seurat` object and do some simple pre-processing as was done for the ATAC-seq data above. Then, you will run joint clustering and visuaization of the combined data set, and finally use the gene expression measurements together with a public data set to annotate the cells.
 
-Before you start, save the seurat object from previous analysis, and then remove all R objects to free up memory.
+Before you start, save the `Seurat` object from previous analysis, and then remove all R objects to free up memory.
 
-```
+```R
 save(pbmc, file="pbmc.Rda")
 rm(list = ls())
 gc()
 ```
 
-Now, read the count tables for the mouse brain data into R. Both these are in the same file, while the meta data is in a separate file.
+Now, read the count tables for the mouse brain data into R. Both tables are in the same file, while the meta data is in a separate file.
 
-```
+```R
 inputdata_10x <- Read10X_h5("data/e18_mouse_brain_fresh_5k_filtered_feature_bc_matrix.h5")
 rna_counts <- inputdata_10x$`Gene Expression`
 mt_index <- grepl("^mt-", rownames(rna_counts))
@@ -678,13 +680,13 @@ metadata <- read.csv(
 
 We start by creating a `Seurat` object with the RNA-seq data.
 
-```
+```R
 seurat_multi <- CreateSeuratObject(counts = rna_counts, meta.data = metadata)
 ```
 
-Then we create a `ChromatinAssay` object from the ATAC-seq data, as we did for the ATAC-seq data above. We add the `ChromatinAssay` to the `Seurat` object with the RNA-seq data. Now the same `Seurat` object hold two assays, one for each data type. *Can you see what these assays are called? Can you see how many peaks and expressed genes we have in our data?*
+Then, we create a `ChromatinAssay` object from the ATAC-seq data, as we did for the ATAC-seq data above. We add the `ChromatinAssay` to the `Seurat` object with the RNA-seq data. Now, the same `Seurat` object holds two assays, one for each data type. *Can you see what these assays are called? Can you see how many peaks and expressed genes we have in our data?*
 
-```
+```R
 # Extract gene annotations from EnsDb
 annotations <- GetGRangesFromEnsDb(ensdb = EnsDb.Mmusculus.v79)
 seqlevelsStyle(annotations) <- 'UCSC'
@@ -717,9 +719,9 @@ seurat_multi
 granges(seurat_multi)
 ```
 
-Next, we calculate quality measures to filter out low quality cells. This step takes around 10 minutes. It's similar to what was done fot the ATAC-seq data above, but now we have quality measures both from RNA-seq and ATAC-seq. *How many cells are left after filtering?*
+Next, we calculate quality measures to filter out low quality cells. This step takes around 10 minutes. It's similar to what was done for the ATAC-seq data above, but now we have quality measures from both RNA-seq and ATAC-seq. *How many cells are left after filtering?*
 
-```
+```R
 # Compute nucleosome signal score per cell
 seurat_multi <- NucleosomeSignal(object = seurat_multi)
 
@@ -752,9 +754,9 @@ seurat_multi <- subset(
 seurat_multi
 ```
 
-Normalization is done on the ATAC-seq and RNA-seq data separately. ATAC-seq data are normalized similar to the example above, while RNA-seq data are normalized using the default seurat methods.
+Normalization is done on the ATAC-seq and RNA-seq data separately. ATAC-seq data are normalized similar to the example above, while RNA-seq data are normalized using the default `Seurat` methods.
 
-```
+```R
 # Normalize ATAC-seq data
 seurat_multi <- RunTFIDF(seurat_multi)
 seurat_multi <- FindTopFeatures(seurat_multi, min.cutoff = 'q5')
@@ -768,9 +770,9 @@ seurat_multi <- ScaleData(seurat_multi)
 seurat_multi <- RunPCA(seurat_multi)
 ```
 
-Let's visualize the data. First we look at RNA-seq and ATAC-seq data separately. *Do you think RNA-seq and ATAC-seq give similar clusterings of the cells?* 
+Let's visualize the data. First, we look at RNA-seq and ATAC-seq data separately. *Do you think RNA-seq and ATAC-seq give similar clusterings of the cells?* 
 
-```
+```R
 # Cluster and visualize RNA-seq
 DefaultAssay(seurat_multi) <- "RNA"
 seurat_multi <- FindNeighbors(seurat_multi, reduction = "pca", dims = 1:30)
@@ -794,7 +796,7 @@ pheatmap(table(seurat_multi$RNA_snn_res.0.5, seurat_multi$ATAC_snn_res.0.5))
 
 Then we analyze the combined data.
 
-```
+```R
 # Analyze combined data set, with Weighted Nearest Neighbor method
 seurat_multi <- FindMultiModalNeighbors(seurat_multi, reduction.list = list("pca", "ATAC_lsi"), 
                                         dims.list = list(1:30, 2:30), k.nn = 30, snn.graph.name = "wsnn_cc",
@@ -808,9 +810,11 @@ DimPlot(seurat_multi, reduction = "wnn_cc_umap", label = T, label.size = 4, repe
 
 ![Umap multi-omics](umap_multi.png)
 
-Let's continue with the clusters based on both RNA- and ATAC-seq data. For each of these clusters, we can check if there are genes that are exclusively expressed in that cluster (or at least at much higher levels than in other clusters). These can be used as marker genes, to get an indication of what cell types the clusters contain. Note that when we use multi-omics data we can use the RNA-seq directly to quantify gene expression, without having to approximate it with gene activite scores like we did in the ATAC-seq example. Using the code below, we find the markers for each cluster and plot the most significant ones.
+Let's continue with the clusters based on both RNA- and ATAC-seq data. For each of these clusters, we can check if there are genes that are exclusively expressed in that cluster (or at least at much higher levels than in other clusters). These can be used as marker genes, to get an indication of what cell types the clusters contain. (Note that when we use multi-omics data we can use the RNA-seq directly to quantify gene expression, without having to approximate it with gene activity scores like we did in the ATAC-seq example.)  
 
-```
+Using the code below, we find markers for each cluster and plot the most significant ones.
+
+```R
 # Cell type markers
 DefaultAssay(seurat_multi) <- "RNA"
 cluster_markers <- FindAllMarkers(seurat_multi, only.pos = TRUE, min.pct = 0.25, logfc.threshold = 0.25)
@@ -824,11 +828,11 @@ DoHeatmap(seurat_multi, features = top10$gene) + NoLegend()
 ![Marker gene expression](marker_genes.png)
 
 
-A more systematic approach than just looking a cluster specific genes, is to compare our the cells in our data set to a reference data set with cell type annotations. There are many methods available for this. In this exercise we will use [SingleR](https://www.nature.com/articles/s41590-018-0276-y). Single R basically correlates the cells in a data set to annotated cell types in a reference data set, using only variable genes.
+A more systematic approach than just looking at cluster-specific genes, is to compare the cells in our data set to a reference data set with cell type annotations. There are many methods available for this. In this exercise, we will use [SingleR](https://www.nature.com/articles/s41590-018-0276-y). `SingleR` correlates the cells in a data set to annotated cell types in a reference data set using only variable genes.
 
-For annotating the cells we will use an annotated data set on mouse brains from [Zeisel et al. (2015)](https://www.science.org/doi/10.1126/science.aaa1934).  We load and preprocess the data set, making sure to pre-process it in exactly the same way as our data. (Note that this data set is from postnatal mice, so it's not ideal for annotating cells from embryos like we have in our data. But here we just use it as an illustration.)
+For annotating the cells, we will use an annotated data set on mouse brains from [Zeisel et al. (2015)](https://www.science.org/doi/10.1126/science.aaa1934). We load and pre-process the data set, making sure to pre-process it in exactly the same way as our data. (Note that this data set is from postnatal mice, so it's not ideal for annotating cells from embryos like we have in our data. But here we just use it as an illustration.)
 
-```
+```R
 # Load and normalize Zeisel et al. (2015) dataset
 zeisel_sce <- ZeiselBrainData()
 seurat_zeisel <- CreateSeuratObject(counts = assay(zeisel_sce))
@@ -838,9 +842,9 @@ seurat_zeisel <- ScaleData(seurat_zeisel)
 seurat_zeisel <- RunPCA(seurat_zeisel)
 ```
 
-Then we are ready to run the actual cell annotation. This method procudes a score for each cell in our data set and each cell type in the reference set, indiciting how similar the cell is to the cell type in the reference data.  *Which cell types seem to be represented in our data? Do different clusters of cells seem to contain different cell types?*
+Then, we are ready to run the actual cell annotation. This method produces a score for each cell in our data set and each cell type in the reference set, indicating how similar the cell is to the cell type in the reference data. *Which cell types seem to be represented in our data? Do different clusters of cells seem to contain different cell types?*
 
-```
+```R
 # Cell type annotation with singleR
 cell_type_pred <- SingleR(test=as.matrix(GetAssayData(object = seurat_multi, slot = "data")), 
                           ref=as.matrix(GetAssayData(object = seurat_zeisel, slot = "data")), 
@@ -868,7 +872,7 @@ After the cell types have been annotated, there is a lot of additional analysis 
 
 - Which promoters and enhancers become active in different cell types and conditions?
 - Can we see if any transcription factor binding sites are active in different cell types and conditions?
-- Are some genes primed for expression, e.g. the promoters show an open chromatin state, but the gene is not expressed yet?
+- Are some genes primed for expression, *e.g.* the promoters show an open chromatin state, but the gene is not expressed yet?
 - ..
 
-Congratulations! You have now reached the end of this exercise, and hopefully you know more about how to analyze single cell ATAC-seq nad multi-omics data than when you started.
+Congratulations! You have now reached the end of this exercise, and hopefully you know more about how to analyze single cell ATAC-seq and multi-omics data than when you started.

--- a/docs/content/tutorials/scAtacSeq/lab-sc_atac_seq.md
+++ b/docs/content/tutorials/scAtacSeq/lab-sc_atac_seq.md
@@ -12,24 +12,24 @@
 **Table of contents**
 
 - [Integrating scATAC-seq and scRNA-seq data](#integrating-scatac-seq-and-scrna-seq-data)
-	- [Learning outcomes](#learning-outcomes)
-	- [Setting up](#setting-up)
-		- [Backup method for setting up](#backup-method-for-setting-up)
-	- [Analysis of single cell ATAC-seq data](#analysis-of-single-cell-atac-seq-data)
-		- [Loading scATAC-seq data](#loading-scatac-seq-data)
-		- [Quality control](#quality-control)
-		- [Normalization and intial dimensionality reduction](#normalization-and-intial-dimensionality-reduction)
-		- [Clustering and further dimensionality reduction](#clustering-and-further-dimensionality-reduction)
-		- [Motif analysis](#motif-analysis)
-			- [Identifying enriched motifs](#identifying-enriched-motifs)
-			- [Motif activity scores](#motif-activity-scores)
-	- [Integrate with scRNA-seq data](#integrate-with-scrna-seq-data)
-		- [Gene activity matrix](#gene-activity-matrix)
-		- [Label transfer](#label-transfer)
-		- [Differentially accessible regions, again](#differentially-accessible-regions-again)
-		- [Annotating regions](#annotating-regions)
-		- [Visualization](#visualization)
-	- [Analysis of multi-omics data](#analysis-of-multi-omics-data)
+  - [Learning outcomes](#learning-outcomes)
+  - [Setting up](#setting-up)
+    - [Backup method for setting up](#backup-method-for-setting-up)
+  - [Analysis of single cell ATAC-seq data](#analysis-of-single-cell-atac-seq-data)
+    - [Loading scATAC-seq data](#loading-scatac-seq-data)
+    - [Quality control](#quality-control)
+    - [Normalization and initial dimensionality reduction](#normalization-and-initial-dimensionality-reduction)
+    - [Clustering and further dimensionality reduction](#clustering-and-further-dimensionality-reduction)
+    - [Motif analysis](#motif-analysis)
+      - [Identifying enriched motifs](#identifying-enriched-motifs)
+      - [Motif activity scores](#motif-activity-scores)
+  - [Integrate with scRNA-seq data](#integrate-with-scrna-seq-data)
+    - [Gene activity matrix](#gene-activity-matrix)
+    - [Label transfer](#label-transfer)
+    - [Differentially accessible regions, again](#differentially-accessible-regions-again)
+    - [Annotating regions](#annotating-regions)
+    - [Visualization](#visualization)
+  - [Analysis of multi-omics data](#analysis-of-multi-omics-data)
 
 
 ## Setting up
@@ -169,24 +169,24 @@ counts <- Read10X_h5(filename = "data/atac_v1_pbmc_10k_filtered_peak_bc_matrix.h
 counts <- counts[, sample(ncol(counts), 2000)] # Only use 2000 cells, to make commands run faster.
 
 metadata <- read.csv(
-	file = "data/atac_v1_pbmc_10k_singlecell.csv",
-	header = TRUE,
-	row.names = 1
+    file = "data/atac_v1_pbmc_10k_singlecell.csv",
+    header = TRUE,
+    row.names = 1
 )
 
 chrom_assay <- CreateChromatinAssay(
-	counts = counts,
-	sep = c(":", "-"),
-	genome = 'hg19',
-	fragments = 'data/atac_v1_pbmc_10k_fragments.tsv.gz',
-	min.cells = 10,
-	min.features = 200
+    counts = counts,
+    sep = c(":", "-"),
+    genome = 'hg19',
+    fragments = 'data/atac_v1_pbmc_10k_fragments.tsv.gz',
+    min.cells = 10,
+    min.features = 200
 )
 
 pbmc <- CreateSeuratObject(
-	counts = chrom_assay,
-	assay = "peaks",
-	meta.data = metadata
+    counts = chrom_assay,
+    assay = "peaks",
+    meta.data = metadata
 )
 
 # Extract gene annotations from EnsDb
@@ -246,11 +246,11 @@ FragmentHistogram(object = pbmc, group.by = 'nucleosome_group')
 
 ```R
 VlnPlot(
-	object = pbmc,
-	features = c('pct_reads_in_peaks', 'peak_region_fragments',
-				 'TSS.enrichment', 'blacklist_ratio', 'nucleosome_signal'),
-	pt.size = 0.1,
-	ncol = 3
+    object = pbmc,
+    features = c('pct_reads_in_peaks', 'peak_region_fragments',
+                 'TSS.enrichment', 'blacklist_ratio', 'nucleosome_signal'),
+    pt.size = 0.1,
+    ncol = 3
 )
 ```
 
@@ -261,19 +261,19 @@ After calculating the qualtiy statistics, we apply (some rather arbitrary) cutof
 
 ```R
 pbmc <- subset(
-	x = pbmc,
-	subset = peak_region_fragments > 3000 &
-		peak_region_fragments < 20000 &
-		pct_reads_in_peaks > 15 &
-		blacklist_ratio < 0.05 &
-		nucleosome_signal < 4 &
-		TSS.enrichment > 2
+    x = pbmc,
+    subset = peak_region_fragments > 3000 &
+             peak_region_fragments < 20000 &
+             pct_reads_in_peaks > 15 &
+             blacklist_ratio < 0.05 &
+             nucleosome_signal < 4 &
+             TSS.enrichment > 2
 )
 pbmc
 ```
 
 
-### Normalization and intial dimensionality reduction
+### Normalization and initial dimensionality reduction
 
 **Normalization:** `Signac` performs term frequency-inverse document frequency (TF-IDF) normalization. This is a two-step normalization procedure, often used in natural language processing, that both normalizes across cells to correct for differences in sequencing depth, and across peaks to give higher values to more rare peaks.
 
@@ -301,12 +301,12 @@ pbmc <- FindNeighbors(object = pbmc, reduction = 'lsi', dims = 2:34, k.param=13)
 pbmc <- FindClusters(object = pbmc, verbose = FALSE)
 
 p1 <- DimPlot(object = pbmc, label = TRUE, dims = c(2, 3), reduction = "lsi") +
-	NoLegend()  +
-	ggtitle('SVD')
+    NoLegend()  +
+    ggtitle('SVD')
 
 p2 <- DimPlot(object = pbmc, label = TRUE) +
-	NoLegend() +
-	ggtitle('UMAP')
+    NoLegend() +
+    ggtitle('UMAP')
 
 p1 | p2
 ```
@@ -334,16 +334,16 @@ First, we will look at motifs that are enriched in a set of peaks, *e.g.* in pea
 ```R
 # Get a list of motif position frequency matrices from the JASPAR database
 pfm <- getMatrixSet(
-	x = JASPAR2020,
-	opts = list(species = "Homo sapiens", all_versions = FALSE)
+    x = JASPAR2020,
+    opts = list(species = "Homo sapiens", all_versions = FALSE)
 )
 
 # Scan the DNA sequence of each peak for the presence of each motif
 motif.matrix <- CreateMotifMatrix(
-	features = granges(pbmc$peaks),
-	pwm = pfm,
-	genome = 'hg19',
-	use.counts = FALSE
+    features = granges(pbmc$peaks),
+    pwm = pfm,
+    genome = 'hg19',
+    use.counts = FALSE
 )
 dim(motif.matrix)
 as.matrix(motif.matrix[1:10,1:10])
@@ -353,16 +353,16 @@ as.matrix(motif.matrix[1:10,1:10])
 ```R
 # Create a new Mofif object to store the results
 motif <- CreateMotifObject(
-	data = motif.matrix,
-	pwm = pfm
+    data = motif.matrix,
+    pwm = pfm
 )
 
 # Add the Motif object to the assay
 pbmc <- SetAssayData(
-	object = pbmc,
-	assay = 'peaks',
-	slot = 'motifs',
-	new.data = motif
+    object = pbmc,
+    assay = 'peaks',
+    slot = 'motifs',
+    new.data = motif
 )
 pbmc$peaks@motifs
 
@@ -372,13 +372,13 @@ pbmc$peaks <- RegionStats(object = pbmc$peaks, genome = BSgenome.Hsapiens.UCSC.h
 
 # Find differentially accessible peaks in cluster 0 compared to cluster 1
 da_peaks <- FindMarkers(
-	object = pbmc,
-	ident.1 = "0",
-	ident.2 = "1",
-	only.pos = TRUE,
-	min.pct = 0.2,
-	test.use = 'LR',
-	latent.vars = 'peak_region_fragments'
+    object = pbmc,
+    ident.1 = "0",
+    ident.2 = "1",
+    only.pos = TRUE,
+    min.pct = 0.2,
+    test.use = 'LR',
+    latent.vars = 'peak_region_fragments'
 )
 
 # Get the top differentially accessible peaks, with lowest p-values
@@ -386,8 +386,8 @@ top.da.peak <- rownames(da_peaks[da_peaks$p_val < 1e-20, ])
 
 # Find motifs enriched in these top differentially accessible peaks
 enriched.motifs <- FindMotifs(
-	object = pbmc,
-	features = top.da.peak
+    object = pbmc,
+    features = top.da.peak
 )
 head(enriched.motifs)
 ```
@@ -395,8 +395,8 @@ head(enriched.motifs)
 ```R
 # Have a look at the most enriched motifs. Do you anything particular about these motifs?
 MotifPlot(
-	object = pbmc,
-	motifs = head(rownames(enriched.motifs))
+    object = pbmc,
+    motifs = head(rownames(enriched.motifs))
 )
 ```
 
@@ -411,9 +411,9 @@ This takes a while to run (around 5 minutes on Uppmax).
 ```R
 # Use chromVAR to calculate the motif activities of all motifs in all cells.
 pbmc <- RunChromVAR(
-	object = pbmc,
-	genome = BSgenome.Hsapiens.UCSC.hg19,
-	verbose = TRUE
+    object = pbmc,
+    genome = BSgenome.Hsapiens.UCSC.hg19,
+    verbose = TRUE
 )
 
 # Look at results
@@ -423,11 +423,11 @@ GetAssayData(pbmc$chromvar)[1:10,1:3]
 # Have a look at the activitiy of the FOS motif, which has id MA0476.1
 DefaultAssay(pbmc) <- 'chromvar'
 FeaturePlot(
-	object = pbmc,
-	features = "MA0476.1",
-	min.cutoff = 'q10',
-	max.cutoff = 'q90',
-	pt.size = 0.1
+    object = pbmc,
+    features = "MA0476.1",
+    min.cutoff = 'q10',
+    max.cutoff = 'q90',
+    pt.size = 0.1
 )
 ```
 
@@ -435,19 +435,19 @@ FeaturePlot(
 ```R
 # Look for motifs that have differential activity between clusters 0 and 1.
 differential.activity <- FindMarkers(
-	object = pbmc,
-	ident.1 = '0',
-	ident.2 = '1',
-	only.pos = TRUE,
-	test.use = 'LR',
-	min.pct = 0.2,
-	latent.vars = 'nCount_peaks'
+    object = pbmc,
+    ident.1 = '0',
+    ident.2 = '1',
+    only.pos = TRUE,
+    test.use = 'LR',
+    min.pct = 0.2,
+    latent.vars = 'nCount_peaks'
 )
 
 MotifPlot(
-  object = pbmc,
-  motifs = head(rownames(differential.activity)),
-  assay = 'peaks'
+    object = pbmc,
+    motifs = head(rownames(differential.activity)),
+    assay = 'peaks'
 )
 ```
 
@@ -473,10 +473,10 @@ gene.activities <- GeneActivity(pbmc)
 # Add the gene activity matrix to the Seurat object as a new assay and normalize it
 pbmc[['RNA']] <- CreateAssayObject(counts = gene.activities)
 pbmc <- NormalizeData(
-	object = pbmc,
-	assay = 'RNA',
-	normalization.method = 'LogNormalize',
-	scale.factor = median(pbmc$nCount_RNA)
+    object = pbmc,
+    assay = 'RNA',
+    normalization.method = 'LogNormalize',
+    scale.factor = median(pbmc$nCount_RNA)
 )
 GetAssayData(pbmc$RNA)[1:10,1:3]
 ```
@@ -485,11 +485,11 @@ GetAssayData(pbmc$RNA)[1:10,1:3]
 ```R
 DefaultAssay(pbmc) <- 'RNA'
 FeaturePlot(
-	object = pbmc,
-	features = c('MS4A1', 'CD3D', 'LEF1', 'NKG7', 'TREM1', 'LYZ'),
-	pt.size = 0.1,
-	max.cutoff = 'q95',
-	ncol = 3
+    object = pbmc,
+    features = c('MS4A1', 'CD3D', 'LEF1', 'NKG7', 'TREM1', 'LYZ'),
+    pt.size = 0.1,
+    max.cutoff = 'q95',
+    ncol = 3
 )
 ```
 
@@ -512,16 +512,16 @@ pbmc_rna <- readRDS("data/pbmc_10k_v3.rds")
 
 # Find anchors
 transfer.anchors <- FindTransferAnchors(
-	reference = pbmc_rna,
-	query = pbmc,
-	reduction = 'cca'
+    reference = pbmc_rna,
+    query = pbmc,
+    reduction = 'cca'
 )
 
 predicted.labels <- TransferData(
-	anchorset = transfer.anchors,
-	refdata = pbmc_rna$celltype,
-	weight.reduction = pbmc[['lsi']],
-	dims = 2:30
+    anchorset = transfer.anchors,
+    refdata = pbmc_rna$celltype,
+    weight.reduction = pbmc[['lsi']],
+    dims = 2:30
 )
 
 pbmc <- AddMetaData(object = pbmc, metadata = predicted.labels)
@@ -529,37 +529,38 @@ gc()
 
 
 plot1 <- DimPlot(
-	object = pbmc_rna,
-	group.by = 'celltype',
-	label = TRUE,
-	repel = TRUE) + NoLegend() + ggtitle('scRNA-seq')
+    object = pbmc_rna,
+    group.by = 'celltype',
+    label = TRUE,
+    repel = TRUE) + NoLegend() + ggtitle('scRNA-seq')
 
 plot2 <- DimPlot(
-	object = pbmc,
-	group.by = 'predicted.id',
-	label = TRUE,
-	repel = TRUE) + NoLegend() + ggtitle('scATAC-seq')
+    object = pbmc,
+    group.by = 'predicted.id',
+    label = TRUE,
+    repel = TRUE) + NoLegend() + ggtitle('scATAC-seq')
 
 plot3 <- DimPlot(
-  object = pbmc,
-  label = TRUE,
-  repel = TRUE) + NoLegend() + ggtitle('scATAC-seq')
+    object = pbmc,
+    label = TRUE,
+    repel = TRUE) + NoLegend() + ggtitle('scATAC-seq')
 
 plot1 | plot2 | plot3
 
 pbmc <- RenameIdents(
-	object = pbmc,
-	'0' = 'CD14 Mono',
-	'1' = 'CD4/8 Naive',
-	'2' = 'CD4 Memory (DN T)',
-	'3' = 'CD14 Mono',
-	'4' = 'CD8 Effector',
-	'5' = 'pre-B/pro-B',
-	'6' = 'NK dim/bright',
-	'7' = 'Double neg. T',
-	'8' = 'CD16 Mono',
-	'9' = 'DC',
-  '10' = 'pDC')
+    object = pbmc,
+    '0' = 'CD14 Mono',
+    '1' = 'CD4/8 Naive',
+    '2' = 'CD4 Memory (DN T)',
+    '3' = 'CD14 Mono',
+    '4' = 'CD8 Effector',
+    '5' = 'pre-B/pro-B',
+    '6' = 'NK dim/bright',
+    '7' = 'Double neg. T',
+    '8' = 'CD16 Mono',
+    '9' = 'DC',
+    '10' = 'pDC'
+)
 ```
 
 ![Labelled clusters](label_transfer.png)
@@ -577,12 +578,12 @@ DefaultAssay(pbmc) <- 'peaks'
 
 # Find differentially acessible regions
 da_peaks <- FindMarkers(
-	object = pbmc,
-	ident.1 = "CD4/8 Naive",
-	ident.2 = "CD14 Mono",
-	min.pct = 0.2,
-	test.use = 'LR',
-	latent.vars = 'peak_region_fragments'
+    object = pbmc,
+    ident.1 = "CD4/8 Naive",
+    ident.2 = "CD14 Mono",
+    min.pct = 0.2,
+    test.use = 'LR',
+    latent.vars = 'peak_region_fragments'
 )
 head(da_peaks)
 ```
@@ -590,16 +591,16 @@ head(da_peaks)
 ```R
 # Plot the signal for the most differentially acessable region.
 plot1 <- VlnPlot(
-	object = pbmc,
-	features = rownames(da_peaks)[1],
-	pt.size = 0.1,
-	idents = c("CD4/8 Naive","CD14 Mono")
+    object = pbmc,
+    features = rownames(da_peaks)[1],
+    pt.size = 0.1,
+    idents = c("CD4/8 Naive","CD14 Mono")
 )
 
 plot2 <- FeaturePlot(
-	object = pbmc,
-	features = rownames(da_peaks)[1],
-	pt.size = 0.1
+    object = pbmc,
+    features = rownames(da_peaks)[1],
+    pt.size = 0.1
 )
 
 plot1 | plot2
@@ -626,21 +627,21 @@ It is often informative to plot the ATAC-seq signal for a particular genomic reg
 
 ```R
 CoveragePlot(
-	object = pbmc,
-	region = rownames(da_peaks)[1],
-	extend.upstream = 40000,
-	extend.downstream = 40000,
-	peaks=TRUE
+    object = pbmc,
+    region = rownames(da_peaks)[1],
+    extend.upstream = 40000,
+    extend.downstream = 40000,
+    peaks=TRUE
 )
 ```
 
 ```R
 TilePlot(
-	object = pbmc,
-	region = rownames(da_peaks)[1],
-	idents = c('CD14 Mono', 'CD4/8 Naive'),
-	extend.upstream = 40000,
-	extend.downstream = 40000
+    object = pbmc,
+    region = rownames(da_peaks)[1],
+    idents = c('CD14 Mono', 'CD4/8 Naive'),
+    extend.upstream = 40000,
+    extend.downstream = 40000
 )
 ```
 
@@ -672,9 +673,9 @@ atac_counts <- atac_counts[, cell_sample]
 rna_counts <- rna_counts[, cell_sample]
 
 metadata <- read.csv(
-  file = "data/e18_mouse_brain_fresh_5k_per_barcode_metrics.csv",
-  header = TRUE,
-  row.names = 1
+    file = "data/e18_mouse_brain_fresh_5k_per_barcode_metrics.csv",
+    header = TRUE,
+    row.names = 1
 )
 ```
 
@@ -698,12 +699,12 @@ seurat_multi <- CreateSeuratObject(counts = rna_counts, meta.data = metadata)
 
 # Load ATAC-seq data
 chrom_assay <- CreateChromatinAssay(
-  counts = atac_counts,
-  sep = c(":", "-"),
-  genome = 'mm10',
-  fragments = 'data/e18_mouse_brain_fresh_5k_atac_fragments.tsv.gz',
-  min.cells = 10,
-  min.features = 1
+    counts = atac_counts,
+    sep = c(":", "-"),
+    genome = 'mm10',
+    fragments = 'data/e18_mouse_brain_fresh_5k_atac_fragments.tsv.gz',
+    min.cells = 10,
+    min.features = 1
 )
 
 
@@ -733,23 +734,23 @@ seurat_multi$pct_reads_in_peaks <- seurat_multi$atac_peak_region_fragments / seu
 
 # Plots
 VlnPlot(
-  object = seurat_multi,
-  features = c('gex_mapped_reads', 'nFeature_RNA', 'nCount_ATAC', 
-               'nFeature_ATAC', 'pct_reads_in_peaks', 'atac_peak_region_fragments',
-               'TSS.enrichment', 'nucleosome_signal'),
-  pt.size = 0.1,
-  ncol = 4
+    object = seurat_multi,
+    features = c('gex_mapped_reads', 'nFeature_RNA', 'nCount_ATAC', 
+                 'nFeature_ATAC', 'pct_reads_in_peaks', 'atac_peak_region_fragments',
+                 'TSS.enrichment', 'nucleosome_signal'),
+    pt.size = 0.1,
+    ncol = 4
 )
 
 seurat_multi <- subset(
-  x = seurat_multi,
-  subset = atac_peak_region_fragments > 2000 &
-    atac_peak_region_fragments < 20000 &
-    pct_reads_in_peaks > 15 &
-    nucleosome_signal < 4 &
-    TSS.enrichment > 2 &
-    nFeature_RNA > 1000 &
-    nFeature_RNA < 5000
+    x = seurat_multi,
+    subset = atac_peak_region_fragments > 2000 &
+             atac_peak_region_fragments < 20000 &
+             pct_reads_in_peaks > 15 &
+             nucleosome_signal < 4 &
+             TSS.enrichment > 2 &
+             nFeature_RNA > 1000 &
+             nFeature_RNA < 5000
 )
 seurat_multi
 ```


### PR DESCRIPTION
This PR contains minor fixes such as typos and formatting.

- Use spaces instead of tabs.
  The mix of tabs and spaces caused Sphinx to render code snippets not correctly formatted. Most likely, the reason is that Sphinx interprets the tab as 8 spaces, which can be different for different editors.
- Add syntax to code snippets.
- TOC was changed to markdown syntax.

The new version was built locally and it renders correctly.